### PR TITLE
Add multi-dimension kernel couplings

### DIFF
--- a/dynamic-neural-field-composer/CMakeLists.txt
+++ b/dynamic-neural-field-composer/CMakeLists.txt
@@ -299,6 +299,7 @@ add_example_executable(ex_two_robot_team ex_two_robot_team.cpp)
 add_example_executable(ex_field_couplings ex_field_couplings.cpp)
 add_example_executable(ex_gauss_and_field_couplings ex_gauss_and_field_couplings.cpp)
 add_example_executable(ex_field_coupling_learning ex_field_coupling_learning.cpp)
+add_example_executable(ex_cross_dimension_kernels ex_cross_dimension_kernels.cpp)
 
 # Tests (GTest)
 option(DNF_COMPOSER_BUILD_TESTS "Build unit tests" ON)
@@ -315,6 +316,7 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "tests/elements/test_gauss_field_coupling.cpp"
             "tests/elements/test_gauss_stimulus.cpp"
             "tests/elements/test_kernels.cpp"
+            "tests/elements/test_kernel_cross_dimension.cpp"
             "tests/elements/test_neural_field.cpp"
             "tests/elements/test_normal_noise.cpp"
             # simulation

--- a/dynamic-neural-field-composer/examples/ex_cross_dimension_kernels.cpp
+++ b/dynamic-neural-field-composer/examples/ex_cross_dimension_kernels.cpp
@@ -1,0 +1,170 @@
+#include "visualization/visualization.h"
+#include "application/application.h"
+#include "user_interface/static_layout_window.h"
+#include "user_interface/main_menu_bar.h"
+#include "elements/neural_field.h"
+#include "elements/gauss_kernel.h"
+#include "elements/mexican_hat_kernel.h"
+#include "elements/normal_noise.h"
+#include "elements/gauss_stimulus.h"
+
+// Demonstrates cross-dimension kernel coupling: neural fields of different spatial
+// sizes connected via kernel elements (GaussKernel and MexicanHatKernel).
+//
+// Architecture:
+//   field_a (100) <--> mhk_a (100)          self-excitation on the source field
+//   field_a (100)  --> gk_ab (in=100,out=50) --> field_b (50)   downscale coupling
+//   field_b (50)  <--> gk_b (50)             self-excitation on the target field
+//   field_b (50)   --> gk_ba (in=50,out=100) --> field_a (100)  upscale feedback
+
+int main()
+{
+	try
+	{
+		using namespace dnf_composer;
+
+		const auto simulation = std::make_shared<Simulation>("cross-dimension kernels", 1.0, 0.0, 0.0);
+		const auto visualization = std::make_shared<Visualization>(simulation);
+		const Application app{ simulation, visualization };
+
+		app.addWindow<user_interface::MainMenuBar>();
+		app.addWindow<user_interface::StaticLayoutWindow>(simulation, visualization);
+
+		// Source field: 100 dimensions
+		const element::ElementDimensions dim_a{ 100, 1.0 };
+		const auto field_a = std::make_shared<element::NeuralField>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"field A (100)"}, dim_a },
+			element::NeuralFieldParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		const auto mhk_a = std::make_shared<element::MexicanHatKernel>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"mhk A self"}, dim_a },
+			element::MexicanHatKernelParameters{ 3.0, 12.0, 6.0, 16.0, -0.1, true, true });
+
+		const auto noise_a = std::make_shared<element::NormalNoise>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"noise A"}, dim_a },
+			element::NormalNoiseParameters{ 0.05 });
+
+		const auto stim_a = std::make_shared<element::GaussStimulus>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"stimulus A"}, dim_a },
+			element::GaussStimulusParameters{ 5.0, 10.0, 30.0 });
+
+		// Target field: 50 dimensions
+		const element::ElementDimensions dim_b{ 50, 1.0 };
+		const auto field_b = std::make_shared<element::NeuralField>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"field B (50)"}, dim_b },
+			element::NeuralFieldParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		const auto gk_b = std::make_shared<element::GaussKernel>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"gk B self"}, dim_b },
+			element::GaussKernelParameters{ 3.0, 3.0, -0.01, true, true });
+
+		const auto noise_b = std::make_shared<element::NormalNoise>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"noise B"}, dim_b },
+			element::NormalNoiseParameters{ 0.05 });
+
+		// Cross-dimension kernels
+		// field_a (100) --> field_b (50): downscale
+		const auto gk_ab = std::make_shared<element::GaussKernel>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"gk A->B (100->50)"}, dim_a },
+			element::GaussKernelParameters{ 5.0, 2.0, -0.005, true, true, element::ElementDimensions{ 50, 1.0 } });
+
+		// field_b (50) --> field_a (100): upscale feedback
+		const auto gk_ba = std::make_shared<element::GaussKernel>(
+			element::ElementCommonParameters{ element::ElementIdentifiers{"gk B->A (50->100)"}, dim_b },
+			element::GaussKernelParameters{ 3.0, 1.5, -0.003, true, true, element::ElementDimensions{ 100, 1.0 } });
+
+		// Add all elements to simulation
+		simulation->addElement(field_a);
+		simulation->addElement(mhk_a);
+		simulation->addElement(noise_a);
+		simulation->addElement(stim_a);
+		simulation->addElement(field_b);
+		simulation->addElement(gk_b);
+		simulation->addElement(noise_b);
+		simulation->addElement(gk_ab);
+		simulation->addElement(gk_ba);
+
+		// Wire field A self-excitation
+		mhk_a->addInput(field_a);
+		field_a->addInput(mhk_a);
+		field_a->addInput(noise_a);
+		field_a->addInput(stim_a);
+
+		// Wire field B self-excitation
+		gk_b->addInput(field_b);
+		field_b->addInput(gk_b);
+		field_b->addInput(noise_b);
+
+		// Wire cross-dimension coupling A --> B (downscale 100 -> 50)
+		gk_ab->addInput(field_a);
+		field_b->addInput(gk_ab);
+
+		// Wire cross-dimension feedback B --> A (upscale 50 -> 100)
+		gk_ba->addInput(field_b);
+		field_a->addInput(gk_ba);
+
+		// Plots
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::LINE_PLOT,
+				PlotDimensions{ 0.0, 100.0, -20.0, 20.0, 1.0, 1.0 },
+				PlotAnnotations{ "Field A (100 dims)", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { field_a->getUniqueName(), "activation" },
+			  { field_a->getUniqueName(), "output" },
+			  { field_a->getUniqueName(), "input" } });
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::LINE_PLOT,
+				PlotDimensions{ 0.0, 50.0, -20.0, 20.0, 1.0, 1.0 },
+				PlotAnnotations{ "Field B (50 dims)", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { field_b->getUniqueName(), "activation" },
+			  { field_b->getUniqueName(), "output" },
+			  { field_b->getUniqueName(), "input" } });
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::LINE_PLOT,
+				PlotDimensions{ 0.0, 50.0, -5.0, 5.0, 1.0, 1.0 },
+				PlotAnnotations{ "Cross-dim kernel A->B output (in 50-dim space)", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { gk_ab->getUniqueName(), "output" } });
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::LINE_PLOT,
+				PlotDimensions{ 0.0, 100.0, -5.0, 5.0, 1.0, 1.0 },
+				PlotAnnotations{ "Cross-dim kernel B->A output (in 100-dim space)", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { gk_ba->getUniqueName(), "output" } });
+
+		app.init();
+
+		while (!app.hasGUIBeenClosed())
+		{
+			app.step();
+		}
+
+		app.close();
+
+		return 0;
+	}
+	catch (const dnf_composer::Exception& ex)
+	{
+		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return static_cast<int>(ex.getErrorCode());
+	}
+	catch (const std::exception& ex)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+	catch (...)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Unknown exception occurred. ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+}

--- a/dynamic-neural-field-composer/include/elements/gauss_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/gauss_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
 #include "tools/math.h"
 #include "kernel.h"
@@ -17,11 +18,14 @@ namespace dnf_composer
 			double amplitudeGlobal;
 			bool circular;
 			bool normalized;
+			std::optional<ElementDimensions> outputFieldDimensions;
 
 			GaussKernelParameters(double width = 3.0, double amp = 3.0, double ampGlobal = -0.01,
-				bool circular = true, bool normalized = true)
+				bool circular = true, bool normalized = true,
+				std::optional<ElementDimensions> outputDims = std::nullopt)
 				: width(width), amplitude(amp), amplitudeGlobal(ampGlobal),
-					circular(circular), normalized(normalized)
+					circular(circular), normalized(normalized),
+					outputFieldDimensions(outputDims)
 			{}
 
 			bool operator==(const GaussKernelParameters& other) const {
@@ -31,7 +35,8 @@ namespace dnf_composer
 					std::abs(amplitude - other.amplitude) < epsilon &&
 					std::abs(amplitudeGlobal - other.amplitudeGlobal) < epsilon &&
 					circular == other.circular &&
-					normalized == other.normalized;
+					normalized == other.normalized &&
+					outputFieldDimensions == other.outputFieldDimensions;
 			}
 
 			std::string toString() const override
@@ -43,8 +48,10 @@ namespace dnf_composer
 					<< "Amplitude: " << amplitude << ", "
 					<< "Amplitude global: " << amplitudeGlobal << ", "
 					<< "Circular: " << (circular ? "true" : "false") << ", "
-					<< "Normalized: " << (normalized ? "true" : "false")
-					<< "]";
+					<< "Normalized: " << (normalized ? "true" : "false");
+				if (outputFieldDimensions.has_value())
+					result << ", Output size: " << outputFieldDimensions->size;
+				result << "]";
 				return result.str();
 			}
 		};

--- a/dynamic-neural-field-composer/include/elements/gauss_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/gauss_kernel.h
@@ -60,6 +60,7 @@ namespace dnf_composer
 		{
 		private:
 			GaussKernelParameters parameters;
+			std::vector<double> scratchConvolution;
 		public:
 			GaussKernel(const ElementCommonParameters& elementCommonParameters, GaussKernelParameters parameters);
 

--- a/dynamic-neural-field-composer/include/elements/mexican_hat_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/mexican_hat_kernel.h
@@ -81,6 +81,7 @@ namespace dnf_composer
 		{
 		private:
 			MexicanHatKernelParameters parameters;
+			std::vector<double> scratchConvolution;
 		public:
 			MexicanHatKernel(const ElementCommonParameters& elementCommonParameters,
 				MexicanHatKernelParameters mhk_parameters);

--- a/dynamic-neural-field-composer/include/elements/mexican_hat_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/mexican_hat_kernel.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <array>
+#include <optional>
 
 #include "kernel.h"
 #include "tools/math.h"
@@ -29,15 +30,18 @@ namespace dnf_composer
 			double amplitudeGlobal;
 			bool circular;
 			bool normalized;
+			std::optional<ElementDimensions> outputFieldDimensions;
 
 			MexicanHatKernelParameters(double widthExc = 2.5, double amplitudeExc = 11.0,
 				double widthInh = 5.0, double amplitudeInh = 15.0,
 				double amplitudeGlobal = -0.1,
-				bool circular = true, bool normalized = true)
+				bool circular = true, bool normalized = true,
+				std::optional<ElementDimensions> outputDims = std::nullopt)
 				: widthExc(widthExc), amplitudeExc(amplitudeExc),
 				widthInh(widthInh), amplitudeInh(amplitudeInh),
 				amplitudeGlobal(amplitudeGlobal),
-				circular(circular), normalized(normalized)
+				circular(circular), normalized(normalized),
+				outputFieldDimensions(outputDims)
 			{}
 
 			bool operator==(const MexicanHatKernelParameters& other) const
@@ -50,7 +54,8 @@ namespace dnf_composer
 					std::abs(amplitudeInh - other.amplitudeInh) < epsilon &&
 					std::abs(amplitudeGlobal - other.amplitudeGlobal) < epsilon &&
 					circular == other.circular &&
-					normalized == other.normalized;
+					normalized == other.normalized &&
+					outputFieldDimensions == other.outputFieldDimensions;
 			}
 
 			std::string toString() const override
@@ -64,8 +69,10 @@ namespace dnf_composer
 					<< "Amplitude inh.: " << amplitudeInh << ", "
 					<< "Amplitude glob.: " << amplitudeGlobal << ", "
 					<< "Circular: " << (circular ? "true" : "false") << ", "
-					<< "Normalized: " << (normalized ? "true" : "false")
-					<< "]";
+					<< "Normalized: " << (normalized ? "true" : "false");
+				if (outputFieldDimensions.has_value())
+					result << ", Output size: " << outputFieldDimensions->size;
+				result << "]";
 				return result.str();
 			}
 		};

--- a/dynamic-neural-field-composer/include/elements/oscillatory_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/oscillatory_kernel.h
@@ -73,6 +73,7 @@ namespace dnf_composer
 		{
 		private:
 			OscillatoryKernelParameters parameters;
+			std::vector<double> scratchConvolution;
 		public:
 			OscillatoryKernel(const ElementCommonParameters& elementCommonParameters,
 				OscillatoryKernelParameters ok_parameters);

--- a/dynamic-neural-field-composer/include/elements/oscillatory_kernel.h
+++ b/dynamic-neural-field-composer/include/elements/oscillatory_kernel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "kernel.h"
 #include "tools/math.h"
 
@@ -15,13 +17,16 @@ namespace dnf_composer
 			double amplitudeGlobal;
 			bool circular;
 			bool normalized;
+			std::optional<ElementDimensions> outputFieldDimensions;
 
 			OscillatoryKernelParameters(double amplitude = 1.0, double decay = 0.08,
 				double zeroCrossings = 0.3, double amplitudeGlobal = -0.01,
-				bool circular = true, bool normalized = false)
+				bool circular = true, bool normalized = false,
+				std::optional<ElementDimensions> outputDims = std::nullopt)
 				: amplitude(amplitude), decay(decay),
 				zeroCrossings(zeroCrossings), amplitudeGlobal(amplitudeGlobal),
-				circular(circular), normalized(normalized)
+				circular(circular), normalized(normalized),
+				outputFieldDimensions(outputDims)
 			{
 				// zero crossings must be in the range [0, 1]
 				if (zeroCrossings < 0.0)
@@ -42,7 +47,8 @@ namespace dnf_composer
 					std::abs(zeroCrossings - other.zeroCrossings) < epsilon &&
 					std::abs(amplitudeGlobal - other.amplitudeGlobal) < epsilon &&
 					circular == other.circular &&
-					normalized == other.normalized;
+					normalized == other.normalized &&
+					outputFieldDimensions == other.outputFieldDimensions;
 			}
 
 			std::string toString() const override
@@ -55,8 +61,10 @@ namespace dnf_composer
 					<< "Zero crossings: " << zeroCrossings << ", "
 					<< "Amplitude global: " << amplitudeGlobal << ", "
 					<< "Circular: " << (circular ? "true" : "false") << ", "
-					<< "Normalized: " << (normalized ? "true" : "false")
-					<< "]";
+					<< "Normalized: " << (normalized ? "true" : "false");
+				if (outputFieldDimensions.has_value())
+					result << ", Output size: " << outputFieldDimensions->size;
+				result << "]";
 				return result.str();
 			}
 		};

--- a/dynamic-neural-field-composer/include/tools/math.h
+++ b/dynamic-neural-field-composer/include/tools/math.h
@@ -461,6 +461,7 @@ namespace dnf_composer::tools::math
 		if (input.empty() || outputSize <= 0) return {};
 		const int N = static_cast<int>(input.size());
 		if (N == outputSize) return input;
+		if (outputSize == 1) return { input[N / 2] };
 		std::vector<T> out(outputSize);
 		for (int i = 0; i < outputSize; ++i)
 		{
@@ -471,5 +472,24 @@ namespace dnf_composer::tools::math
 			out[i] = input[lo] * (1.0 - t) + input[hi] * t;
 		}
 		return out;
+	}
+
+	// In-place variant: writes into a pre-sized output buffer to avoid heap allocation.
+	template<typename T>
+	void resampleInto(const std::vector<T>& input, std::vector<T>& output)
+	{
+		const int N = static_cast<int>(input.size());
+		const int outputSize = static_cast<int>(output.size());
+		if (input.empty() || outputSize <= 0) return;
+		if (N == outputSize) { std::copy(input.begin(), input.end(), output.begin()); return; }
+		if (outputSize == 1) { output[0] = input[N / 2]; return; }
+		for (int i = 0; i < outputSize; ++i)
+		{
+			const double pos = static_cast<double>(i) * (N - 1) / (outputSize - 1);
+			const int lo = static_cast<int>(pos);
+			const int hi = std::min(lo + 1, N - 1);
+			const double t = pos - lo;
+			output[i] = input[lo] * (1.0 - t) + input[hi] * t;
+		}
 	}
 }

--- a/dynamic-neural-field-composer/include/tools/math.h
+++ b/dynamic-neural-field-composer/include/tools/math.h
@@ -453,4 +453,23 @@ namespace dnf_composer::tools::math
 				flat_matrix[i * cols + j] = static_cast<T>(matrix[i][j]);
 		return flat_matrix;
 	}
+
+	// Linear interpolation resampling from input.size() to outputSize.
+	template<typename T>
+	std::vector<T> resample(const std::vector<T>& input, int outputSize)
+	{
+		if (input.empty() || outputSize <= 0) return {};
+		const int N = static_cast<int>(input.size());
+		if (N == outputSize) return input;
+		std::vector<T> out(outputSize);
+		for (int i = 0; i < outputSize; ++i)
+		{
+			const double pos = static_cast<double>(i) * (N - 1) / (outputSize - 1);
+			const int lo = static_cast<int>(pos);
+			const int hi = std::min(lo + 1, N - 1);
+			const double t = pos - lo;
+			out[i] = input[lo] * (1.0 - t) + input[hi] * t;
+		}
+		return out;
+	}
 }

--- a/dynamic-neural-field-composer/src/elements/gauss_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/gauss_kernel.cpp
@@ -14,6 +14,8 @@ namespace dnf_composer
 		{
 			commonParameters.identifiers.label = ElementLabel::GAUSS_KERNEL;
 			components["kernel"] = std::vector<double>(commonParameters.dimensionParameters.size);
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].resize(parameters.outputFieldDimensions->size, 0.0);
 		}
 
 		void GaussKernel::init()
@@ -48,7 +50,10 @@ namespace dnf_composer
 			 
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
-			std::ranges::fill(components["output"], 0.0);
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].assign(parameters.outputFieldDimensions->size, 0.0);
+			else
+				std::ranges::fill(components["output"], 0.0);
 		}
 
 		void GaussKernel::step(double t, double deltaT)
@@ -66,8 +71,19 @@ namespace dnf_composer
 			else
 				convolution = tools::math::conv_same(components["input"], components["kernel"]);
 
-			for (int i = 0; i < components["output"].size(); i++)
-				components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			if (parameters.outputFieldDimensions.has_value() &&
+				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
+			{
+				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
+				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
+					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+			}
+			else
+			{
+				for (int i = 0; i < static_cast<int>(components["output"].size()); i++)
+					components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			}
 		}
 
 		std::string GaussKernel::toString() const

--- a/dynamic-neural-field-composer/src/elements/gauss_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/gauss_kernel.cpp
@@ -48,6 +48,7 @@ namespace dnf_composer
 			for (int i = 0; i < components["kernel"].size(); i++)
 				components["kernel"][i] = parameters.amplitude * gauss[i];
 			 
+			scratchConvolution.assign(commonParameters.dimensionParameters.size, 0.0);
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
 			if (parameters.outputFieldDimensions.has_value())
@@ -74,10 +75,9 @@ namespace dnf_composer
 			if (parameters.outputFieldDimensions.has_value() &&
 				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
 			{
-				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
-				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
-					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
-				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+				for (int i = 0; i < static_cast<int>(scratchConvolution.size()); i++)
+					scratchConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				tools::math::resampleInto(scratchConvolution, components["output"]);
 			}
 			else
 			{

--- a/dynamic-neural-field-composer/src/elements/mexican_hat_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/mexican_hat_kernel.cpp
@@ -12,6 +12,8 @@ namespace dnf_composer
 			: Kernel(elementCommonParameters), parameters(std::move(mhk_parameters))
 		{
 			commonParameters.identifiers.label = ElementLabel::MEXICAN_HAT_KERNEL;
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].resize(parameters.outputFieldDimensions->size, 0.0);
 		}
 
 		void MexicanHatKernel::init()
@@ -52,7 +54,10 @@ namespace dnf_composer
 
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
-			std::ranges::fill(components["output"], 0.0);  
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].assign(parameters.outputFieldDimensions->size, 0.0);
+			else
+				std::ranges::fill(components["output"], 0.0);
 		}
 
 		void MexicanHatKernel::step(double t, double deltaT)
@@ -71,8 +76,19 @@ namespace dnf_composer
 			else
 				convolution = tools::math::conv_same(components["input"], components["kernel"]);
 
-			for (int i = 0; i < components["output"].size(); i++)
-				components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			if (parameters.outputFieldDimensions.has_value() &&
+				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
+			{
+				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
+				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
+					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+			}
+			else
+			{
+				for (int i = 0; i < static_cast<int>(components["output"].size()); i++)
+					components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			}
 		}
 
 		std::string MexicanHatKernel::toString() const

--- a/dynamic-neural-field-composer/src/elements/mexican_hat_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/mexican_hat_kernel.cpp
@@ -52,6 +52,7 @@ namespace dnf_composer
 				components["kernel"][i] = parameters.amplitudeExc * gaussExc[i] -
 				parameters.amplitudeInh * gaussInh[i];
 
+			scratchConvolution.assign(commonParameters.dimensionParameters.size, 0.0);
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
 			if (parameters.outputFieldDimensions.has_value())
@@ -79,10 +80,9 @@ namespace dnf_composer
 			if (parameters.outputFieldDimensions.has_value() &&
 				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
 			{
-				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
-				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
-					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
-				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+				for (int i = 0; i < static_cast<int>(scratchConvolution.size()); i++)
+					scratchConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				tools::math::resampleInto(scratchConvolution, components["output"]);
 			}
 			else
 			{

--- a/dynamic-neural-field-composer/src/elements/oscillatory_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/oscillatory_kernel.cpp
@@ -9,11 +9,13 @@ namespace dnf_composer
 {
 	namespace element
 	{
-		OscillatoryKernel::OscillatoryKernel(const ElementCommonParameters& elementCommonParameters, 
+		OscillatoryKernel::OscillatoryKernel(const ElementCommonParameters& elementCommonParameters,
 			OscillatoryKernelParameters ok_parameters)
 			: Kernel(elementCommonParameters), parameters(std::move(ok_parameters))
 		{
 			commonParameters.identifiers.label = ElementLabel::OSCILLATORY_KERNEL;
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].resize(parameters.outputFieldDimensions->size, 0.0);
 		}
 
 		void OscillatoryKernel::init()
@@ -56,7 +58,10 @@ namespace dnf_composer
 
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
-			std::ranges::fill(components["output"], 0.0);
+			if (parameters.outputFieldDimensions.has_value())
+				components["output"].assign(parameters.outputFieldDimensions->size, 0.0);
+			else
+				std::ranges::fill(components["output"], 0.0);
 		}
 
 		void OscillatoryKernel::step(double t, double deltaT)
@@ -75,8 +80,19 @@ namespace dnf_composer
 			else
 				convolution = tools::math::conv_same(components["input"], components["kernel"]);
 
-			for (int i = 0; i < components["output"].size(); i++)
-				components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			if (parameters.outputFieldDimensions.has_value() &&
+				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
+			{
+				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
+				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
+					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+			}
+			else
+			{
+				for (int i = 0; i < static_cast<int>(components["output"].size()); i++)
+					components["output"][i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+			}
 		}
 
 		std::string OscillatoryKernel::toString() const

--- a/dynamic-neural-field-composer/src/elements/oscillatory_kernel.cpp
+++ b/dynamic-neural-field-composer/src/elements/oscillatory_kernel.cpp
@@ -56,6 +56,7 @@ namespace dnf_composer
 				}
 			}
 
+			scratchConvolution.assign(commonParameters.dimensionParameters.size, 0.0);
 			fullSum = 0.0;
 			std::ranges::fill(components["input"], 0.0);
 			if (parameters.outputFieldDimensions.has_value())
@@ -83,10 +84,9 @@ namespace dnf_composer
 			if (parameters.outputFieldDimensions.has_value() &&
 				parameters.outputFieldDimensions->size != commonParameters.dimensionParameters.size)
 			{
-				std::vector<double> fullConvolution(commonParameters.dimensionParameters.size);
-				for (int i = 0; i < static_cast<int>(fullConvolution.size()); i++)
-					fullConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
-				components["output"] = tools::math::resample(fullConvolution, parameters.outputFieldDimensions->size);
+				for (int i = 0; i < static_cast<int>(scratchConvolution.size()); i++)
+					scratchConvolution[i] = convolution[i] + parameters.amplitudeGlobal * fullSum;
+				tools::math::resampleInto(scratchConvolution, components["output"]);
 			}
 			else
 			{

--- a/dynamic-neural-field-composer/src/user_interface/element_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/element_window.cpp
@@ -461,7 +461,6 @@ namespace dnf_composer::user_interface
 		ImGui::SameLine(); ImGui::Checkbox(label.c_str(), &normalized);
 		ImGui::SameLine(); ImGui::Text("Normalized");
 
-
 		static constexpr double epsilon = 1e-6;
 		if(std::abs(amplitudeExc - static_cast<float>(mhkp.amplitudeExc)) > epsilon ||
 			std::abs(widthExc - static_cast<float>(mhkp.widthExc)) > epsilon ||
@@ -683,7 +682,6 @@ namespace dnf_composer::user_interface
 		label = "##" + element->getUniqueName() + "Normalized";
 		ImGui::SameLine(); ImGui::Checkbox(label.c_str(), &normalized);
 		ImGui::SameLine(); ImGui::Text("Normalized");
-
 
 		static constexpr double epsilon = 1e-6;
 		if (std::abs(amplitude - static_cast<float>(okp.amplitude)) > epsilon ||

--- a/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
@@ -419,11 +419,25 @@ namespace dnf_composer::user_interface
             static double amplitudeGlobal = -0.01;
             static bool   circular        = true;
             static bool   normalized      = true;
+            static int    out_x_max       = 100;
+            static double out_d_x         = 1.0;
 
             ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
             ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputInt("Size",           &x_max,           0, 0);
+            ImGui::InputInt("Out size",       &out_x_max,       0, 0);
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            widgets::renderHelpMarker(
+                "Output field size for cross-dimension coupling.\n"
+                "Set this to the size of the destination field when connecting\n"
+                "fields of different spatial dimensions via this kernel.\n"
+                "The kernel convolves in input space, then linearly resamples\n"
+                "the result to the output size before passing it downstream.\n"
+                "Leave equal to 'Size' (default) for standard same-dimension coupling.");
+            ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputDouble("Step",        &d_x,             0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Out step",    &out_d_x,         0.0, 0.0, "%.2f");
             ImGui::InputDouble("Width",       &width,           0.0, 0.0, "%.2f");
             ImGui::InputDouble("Amplitude",   &amplitude,       0.0, 0.0, "%.2f");
             ImGui::InputDouble("Global amp",  &amplitudeGlobal, 0.0, 0.0, "%.4f");
@@ -433,7 +447,11 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
-                const element::GaussKernelParameters gkp{ width, amplitude, amplitudeGlobal, circular, normalized };
+                const std::optional<element::ElementDimensions> outputDims =
+                    (out_x_max != x_max)
+                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    : std::nullopt;
+                const element::GaussKernelParameters gkp{ width, amplitude, amplitudeGlobal, circular, normalized, outputDims };
                 const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
                 simulation->addElement(std::make_shared<element::GaussKernel>(common, gkp));
             }
@@ -451,11 +469,25 @@ namespace dnf_composer::user_interface
             static double amplitudeGlobal = -0.1;
             static bool   circular        = true;
             static bool   normalized      = true;
+            static int    out_x_max       = 100;
+            static double out_d_x         = 1.0;
 
             ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
             ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputInt("Size",             &x_max,           0, 0);
+            ImGui::InputInt("Out size",         &out_x_max,       0, 0);
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            widgets::renderHelpMarker(
+                "Output field size for cross-dimension coupling.\n"
+                "Set this to the size of the destination field when connecting\n"
+                "fields of different spatial dimensions via this kernel.\n"
+                "The kernel convolves in input space, then linearly resamples\n"
+                "the result to the output size before passing it downstream.\n"
+                "Leave equal to 'Size' (default) for standard same-dimension coupling.");
+            ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputDouble("Step",          &d_x,             0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Out step",      &out_d_x,         0.0, 0.0, "%.2f");
             ImGui::InputDouble("Width exc",     &widthExc,        0.0, 0.0, "%.2f");
             ImGui::InputDouble("Amplitude exc", &amplitudeExc,    0.0, 0.0, "%.2f");
             ImGui::InputDouble("Width inh",     &widthInh,        0.0, 0.0, "%.2f");
@@ -467,7 +499,11 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
-                const element::MexicanHatKernelParameters mhkp{ widthExc, amplitudeExc, widthInh, amplitudeInh, amplitudeGlobal, circular, normalized };
+                const std::optional<element::ElementDimensions> outputDims =
+                    (out_x_max != x_max)
+                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    : std::nullopt;
+                const element::MexicanHatKernelParameters mhkp{ widthExc, amplitudeExc, widthInh, amplitudeInh, amplitudeGlobal, circular, normalized, outputDims };
                 const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
                 simulation->addElement(std::make_shared<element::MexicanHatKernel>(common, mhkp));
             }
@@ -484,11 +520,25 @@ namespace dnf_composer::user_interface
             static double amplitudeGlobal = -0.01;
             static bool   circular        = true;
             static bool   normalized      = false;
+            static int    out_x_max       = 100;
+            static double out_d_x         = 1.0;
 
             ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
             ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputInt("Size",              &x_max,           0, 0);
+            ImGui::InputInt("Out size",          &out_x_max,       0, 0);
+            ImGui::PopItemWidth();
+            ImGui::SameLine();
+            widgets::renderHelpMarker(
+                "Output field size for cross-dimension coupling.\n"
+                "Set this to the size of the destination field when connecting\n"
+                "fields of different spatial dimensions via this kernel.\n"
+                "The kernel convolves in input space, then linearly resamples\n"
+                "the result to the output size before passing it downstream.\n"
+                "Leave equal to 'Size' (default) for standard same-dimension coupling.");
+            ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
             ImGui::InputDouble("Step",           &d_x,             0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Out step",       &out_d_x,         0.0, 0.0, "%.2f");
             ImGui::InputDouble("Amplitude",      &amplitude,       0.0, 0.0, "%.2f");
             ImGui::InputDouble("Decay",          &decay,           0.0, 0.0, "%.4f");
             ImGui::InputDouble("Zero crossings", &zeroCrossings,   0.0, 0.0, "%.2f");
@@ -499,7 +549,11 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
-                const element::OscillatoryKernelParameters okp{ amplitude, decay, zeroCrossings, amplitudeGlobal, circular, normalized };
+                const std::optional<element::ElementDimensions> outputDims =
+                    (out_x_max != x_max)
+                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    : std::nullopt;
+                const element::OscillatoryKernelParameters okp{ amplitude, decay, zeroCrossings, amplitudeGlobal, circular, normalized, outputDims };
                 const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
                 simulation->addElement(std::make_shared<element::OscillatoryKernel>(common, okp));
             }

--- a/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
@@ -447,12 +447,14 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
+                const element::ElementDimensions inDims{ x_max, d_x };
+                const element::ElementDimensions outDims{ out_x_max, out_d_x };
                 const std::optional<element::ElementDimensions> outputDims =
-                    (out_x_max != x_max)
-                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    (outDims.size != inDims.size)
+                    ? std::make_optional(outDims)
                     : std::nullopt;
                 const element::GaussKernelParameters gkp{ width, amplitude, amplitudeGlobal, circular, normalized, outputDims };
-                const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
+                const element::ElementCommonParameters common{ std::string(id), inDims };
                 simulation->addElement(std::make_shared<element::GaussKernel>(common, gkp));
             }
             break;
@@ -499,12 +501,14 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
+                const element::ElementDimensions inDims{ x_max, d_x };
+                const element::ElementDimensions outDims{ out_x_max, out_d_x };
                 const std::optional<element::ElementDimensions> outputDims =
-                    (out_x_max != x_max)
-                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    (outDims.size != inDims.size)
+                    ? std::make_optional(outDims)
                     : std::nullopt;
                 const element::MexicanHatKernelParameters mhkp{ widthExc, amplitudeExc, widthInh, amplitudeInh, amplitudeGlobal, circular, normalized, outputDims };
-                const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
+                const element::ElementCommonParameters common{ std::string(id), inDims };
                 simulation->addElement(std::make_shared<element::MexicanHatKernel>(common, mhkp));
             }
             break;
@@ -549,12 +553,14 @@ namespace dnf_composer::user_interface
 
             if (addRequested)
             {
+                const element::ElementDimensions inDims{ x_max, d_x };
+                const element::ElementDimensions outDims{ out_x_max, out_d_x };
                 const std::optional<element::ElementDimensions> outputDims =
-                    (out_x_max != x_max)
-                    ? std::make_optional<element::ElementDimensions>(out_x_max, out_d_x)
+                    (outDims.size != inDims.size)
+                    ? std::make_optional(outDims)
                     : std::nullopt;
                 const element::OscillatoryKernelParameters okp{ amplitude, decay, zeroCrossings, amplitudeGlobal, circular, normalized, outputDims };
-                const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
+                const element::ElementCommonParameters common{ std::string(id), inDims };
                 simulation->addElement(std::make_shared<element::OscillatoryKernel>(common, okp));
             }
             break;

--- a/dynamic-neural-field-composer/tests/elements/test_kernel_cross_dimension.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_kernel_cross_dimension.cpp
@@ -96,6 +96,16 @@ TEST(ResampleTest, ZeroOutputSizeReturnsEmpty)
     EXPECT_TRUE(tools::math::resample(v, 0).empty());
 }
 
+TEST(ResampleTest, SingleOutputSizeReturnsCenterSample)
+{
+    // outputSize == 1 must not divide by (outputSize - 1) == 0
+    const std::vector<double> v{ 10.0, 20.0, 30.0, 40.0 };
+    const auto result = tools::math::resample(v, 1);
+    ASSERT_EQ(result.size(), 1u);
+    // center index: N/2 == 2 → v[2] == 30.0
+    EXPECT_DOUBLE_EQ(result[0], v[v.size() / 2]);
+}
+
 // ---------------------------------------------------------------------------
 // GaussKernel cross-dimension
 // ---------------------------------------------------------------------------

--- a/dynamic-neural-field-composer/tests/elements/test_kernel_cross_dimension.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_kernel_cross_dimension.cpp
@@ -1,0 +1,270 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <numeric>
+
+#include "elements/gauss_kernel.h"
+#include "elements/mexican_hat_kernel.h"
+#include "elements/oscillatory_kernel.h"
+#include "elements/neural_field.h"
+#include "elements/activation_function.h"
+#include "simulation/simulation.h"
+#include "tools/math.h"
+
+using namespace dnf_composer;
+using namespace dnf_composer::element;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::shared_ptr<NeuralField> makeField(const std::string& name, int size)
+{
+    const SigmoidFunction sig{ 0.0, 10.0 };
+    NeuralFieldParameters nfp{ 25.0, -5.0, sig };
+    ElementCommonParameters cp{ name, size };
+    return std::make_shared<NeuralField>(cp, nfp);
+}
+
+static std::shared_ptr<GaussKernel> makeGaussKernel(const std::string& name, int inputSize,
+    std::optional<ElementDimensions> outputDims = std::nullopt)
+{
+    GaussKernelParameters gkp{ 3.0, 3.0, -0.01, true, true, outputDims };
+    ElementCommonParameters cp{ name, inputSize };
+    return std::make_shared<GaussKernel>(cp, gkp);
+}
+
+static std::shared_ptr<MexicanHatKernel> makeMexKernel(const std::string& name, int inputSize,
+    std::optional<ElementDimensions> outputDims = std::nullopt)
+{
+    MexicanHatKernelParameters mhkp{ 2.5, 11.0, 5.0, 15.0, -0.1, true, true, outputDims };
+    ElementCommonParameters cp{ name, inputSize };
+    return std::make_shared<MexicanHatKernel>(cp, mhkp);
+}
+
+static std::shared_ptr<OscillatoryKernel> makeOscKernel(const std::string& name, int inputSize,
+    std::optional<ElementDimensions> outputDims = std::nullopt)
+{
+    OscillatoryKernelParameters okp{ 1.0, 0.08, 0.3, -0.01, true, false, outputDims };
+    ElementCommonParameters cp{ name, inputSize };
+    return std::make_shared<OscillatoryKernel>(cp, okp);
+}
+
+// ---------------------------------------------------------------------------
+// tools::math::resample unit tests
+// ---------------------------------------------------------------------------
+
+TEST(ResampleTest, SameSizeReturnsIdentical)
+{
+    const std::vector<double> v{ 1.0, 2.0, 3.0, 4.0 };
+    const auto result = tools::math::resample(v, 4);
+    ASSERT_EQ(result.size(), 4u);
+    for (int i = 0; i < 4; ++i)
+        EXPECT_DOUBLE_EQ(result[i], v[i]);
+}
+
+TEST(ResampleTest, HalfSizePicksEndpoints)
+{
+    // 4 → 2: positions 0.0 and 1.0 → indices 0 and 3
+    const std::vector<double> v{ 10.0, 20.0, 30.0, 40.0 };
+    const auto result = tools::math::resample(v, 2);
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_DOUBLE_EQ(result[0], 10.0);
+    EXPECT_DOUBLE_EQ(result[1], 40.0);
+}
+
+TEST(ResampleTest, DoubleSizeInterpolates)
+{
+    // 2 → 4: positions 0, 1/3, 2/3, 1 → 0, 0.333, 0.666, 1.0 of [0..1]
+    const std::vector<double> v{ 0.0, 3.0 };
+    const auto result = tools::math::resample(v, 4);
+    ASSERT_EQ(result.size(), 4u);
+    EXPECT_DOUBLE_EQ(result[0], 0.0);
+    EXPECT_NEAR(result[1], 1.0, 1e-9);
+    EXPECT_NEAR(result[2], 2.0, 1e-9);
+    EXPECT_DOUBLE_EQ(result[3], 3.0);
+}
+
+TEST(ResampleTest, EmptyInputReturnsEmpty)
+{
+    const std::vector<double> v;
+    EXPECT_TRUE(tools::math::resample(v, 5).empty());
+}
+
+TEST(ResampleTest, ZeroOutputSizeReturnsEmpty)
+{
+    const std::vector<double> v{ 1.0, 2.0 };
+    EXPECT_TRUE(tools::math::resample(v, 0).empty());
+}
+
+// ---------------------------------------------------------------------------
+// GaussKernel cross-dimension
+// ---------------------------------------------------------------------------
+
+TEST(GaussKernelCrossDim, OutputSizeMatchesTargetAfterConstruction)
+{
+    const auto gk = makeGaussKernel("gk", 100, ElementDimensions{ 50 });
+    EXPECT_EQ(gk->getComponentPtr("output")->size(), 50u);
+}
+
+TEST(GaussKernelCrossDim, SameDimFallbackHasOriginalOutputSize)
+{
+    const auto gk = makeGaussKernel("gk", 100);
+    EXPECT_EQ(gk->getComponentPtr("output")->size(), 100u);
+}
+
+TEST(GaussKernelCrossDim, ConnectionFromLargerToSmallerField)
+{
+    // Field 100 → GaussKernel(in=100, out=50) → Field 50
+    const auto fieldSrc = makeField("src", 100);
+    const auto gk = makeGaussKernel("gk", 100, ElementDimensions{ 50 });
+    const auto fieldDst = makeField("dst", 50);
+
+    EXPECT_NO_THROW(gk->addInput(fieldSrc));
+    EXPECT_NO_THROW(fieldDst->addInput(gk));
+
+    EXPECT_EQ(gk->getInputs().size(), 1u);
+    EXPECT_EQ(fieldDst->getInputs().size(), 1u);
+}
+
+TEST(GaussKernelCrossDim, ConnectionFromSmallerToLargerField)
+{
+    // Field 50 → GaussKernel(in=50, out=100) → Field 100
+    const auto fieldSrc = makeField("src", 50);
+    const auto gk = makeGaussKernel("gk", 50, ElementDimensions{ 100 });
+    const auto fieldDst = makeField("dst", 100);
+
+    EXPECT_NO_THROW(gk->addInput(fieldSrc));
+    EXPECT_NO_THROW(fieldDst->addInput(gk));
+}
+
+TEST(GaussKernelCrossDim, StepProducesCorrectOutputSize)
+{
+    const auto fieldSrc = makeField("src", 100);
+    const auto gk = makeGaussKernel("gk", 100, ElementDimensions{ 50 });
+    const auto fieldDst = makeField("dst", 50);
+
+    gk->addInput(fieldSrc);
+    fieldDst->addInput(gk);
+
+    fieldSrc->init();
+    gk->init();
+    fieldDst->init();
+
+    fieldSrc->step(0.0, 1.0);
+    gk->step(0.0, 1.0);
+    fieldDst->step(0.0, 1.0);
+
+    EXPECT_EQ(gk->getComponentPtr("output")->size(), 50u);
+}
+
+TEST(GaussKernelCrossDim, SimulationRunsWithCrossDimensionKernel)
+{
+    const auto sim = createSimulation("cross-dim-gauss", 1.0, 0.0, 0.0);
+    sim->addElement(makeField("src", 100));
+    sim->addElement(makeGaussKernel("gk", 100, ElementDimensions{ 50 }));
+    sim->addElement(makeField("dst", 50));
+
+    sim->createInteraction("src", "output", "gk");
+    sim->createInteraction("gk", "output", "dst");
+
+    EXPECT_NO_THROW(sim->init());
+    EXPECT_NO_THROW(sim->step());
+    EXPECT_NO_THROW(sim->step());
+}
+
+TEST(GaussKernelCrossDim, ParametersRoundTrip)
+{
+    const GaussKernelParameters p{ 3.0, 3.0, -0.01, true, true, ElementDimensions{ 50 } };
+    EXPECT_TRUE(p.outputFieldDimensions.has_value());
+    EXPECT_EQ(p.outputFieldDimensions->size, 50);
+    EXPECT_FALSE(p.toString().empty());
+    EXPECT_TRUE(p.toString().find("Output size") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// MexicanHatKernel cross-dimension
+// ---------------------------------------------------------------------------
+
+TEST(MexicanHatKernelCrossDim, OutputSizeMatchesTargetAfterConstruction)
+{
+    const auto mhk = makeMexKernel("mhk", 100, ElementDimensions{ 200 });
+    EXPECT_EQ(mhk->getComponentPtr("output")->size(), 200u);
+}
+
+TEST(MexicanHatKernelCrossDim, StepProducesCorrectOutputSize)
+{
+    const auto fieldSrc = makeField("src", 100);
+    const auto mhk = makeMexKernel("mhk", 100, ElementDimensions{ 200 });
+    const auto fieldDst = makeField("dst", 200);
+
+    mhk->addInput(fieldSrc);
+    fieldDst->addInput(mhk);
+
+    fieldSrc->init();
+    mhk->init();
+    fieldDst->init();
+
+    fieldSrc->step(0.0, 1.0);
+    mhk->step(0.0, 1.0);
+    fieldDst->step(0.0, 1.0);
+
+    EXPECT_EQ(mhk->getComponentPtr("output")->size(), 200u);
+}
+
+TEST(MexicanHatKernelCrossDim, SimulationRunsWithCrossDimensionKernel)
+{
+    const auto sim = createSimulation("cross-dim-mhk", 1.0, 0.0, 0.0);
+    sim->addElement(makeField("src", 100));
+    sim->addElement(makeMexKernel("mhk", 100, ElementDimensions{ 200 }));
+    sim->addElement(makeField("dst", 200));
+
+    sim->createInteraction("src", "output", "mhk");
+    sim->createInteraction("mhk", "output", "dst");
+
+    EXPECT_NO_THROW(sim->init());
+    EXPECT_NO_THROW(sim->step());
+}
+
+// ---------------------------------------------------------------------------
+// OscillatoryKernel cross-dimension
+// ---------------------------------------------------------------------------
+
+TEST(OscillatoryKernelCrossDim, OutputSizeMatchesTargetAfterConstruction)
+{
+    const auto ok = makeOscKernel("ok", 100, ElementDimensions{ 75 });
+    EXPECT_EQ(ok->getComponentPtr("output")->size(), 75u);
+}
+
+TEST(OscillatoryKernelCrossDim, StepProducesCorrectOutputSize)
+{
+    const auto fieldSrc = makeField("src", 100);
+    const auto ok = makeOscKernel("ok", 100, ElementDimensions{ 75 });
+    const auto fieldDst = makeField("dst", 75);
+
+    ok->addInput(fieldSrc);
+    fieldDst->addInput(ok);
+
+    fieldSrc->init();
+    ok->init();
+    fieldDst->init();
+
+    fieldSrc->step(0.0, 1.0);
+    ok->step(0.0, 1.0);
+    fieldDst->step(0.0, 1.0);
+
+    EXPECT_EQ(ok->getComponentPtr("output")->size(), 75u);
+}
+
+TEST(OscillatoryKernelCrossDim, SimulationRunsWithCrossDimensionKernel)
+{
+    const auto sim = createSimulation("cross-dim-osc", 1.0, 0.0, 0.0);
+    sim->addElement(makeField("src", 100));
+    sim->addElement(makeOscKernel("ok", 100, ElementDimensions{ 75 }));
+    sim->addElement(makeField("dst", 75));
+
+    sim->createInteraction("src", "output", "ok");
+    sim->createInteraction("ok", "output", "dst");
+
+    EXPECT_NO_THROW(sim->init());
+    EXPECT_NO_THROW(sim->step());
+}


### PR DESCRIPTION
`include/tools/math.h` — Added `tools::math::resample()`: linearly interpolates a vector from N to M samples, used to resize kernel output to the target field's size.

`include/elements/gauss_kernel.h`, `mexican_hat_kernel.h`, `oscillatory_kernel.h` — Added std::optional<ElementDimensions> outputFieldDimensions to each kernel's parameter struct. When set, the kernel convolves in input space (size N) then resamples output to size M.

`src/elements/gauss_kernel.cpp,` `mexican_hat_kernel.cpp, oscillatory_kernel.cpp` — Constructor and `init()` resize `components["output"]` to M immediately when outputFieldDimensions is set, so the addInput() dimension check passes at wiring time (before init() is called). step() resamples the convolution result when M ≠ N.

`tests/elements/test_kernel_cross_dimension.cpp` — New test file covering resample correctness, output size after construction, same/cross-dimension connections, step output size, and simulation runs — for all three kernel types.

`examples/ex_cross_dimension_kernels.cpp` — New GUI example: Field A (100) ↔ Field B (50) via cross-dimension GaussKernels, with plots showing both fields and both kernel outputs.

`CMakeLists.txt` — Registered the new test file and new example executable.

`src/user_interface/simulation_window.cpp `— In the "Add element" form, the three kernel cases (GaussKernel, MexicanHatKernel, OscillatoryKernel) now expose two extra fields placed immediately after Size/Step:

Out size — target field size (defaults to same as Size; a (?) tooltip explains cross-dimension coupling)
Out step — spatial step of the target field
If Out size ≠ Size at creation time, outputFieldDimensions is set via std::make_optional<ElementDimensions>(out_x_max, out_d_x); otherwise std::nullopt (backward-compatible, same-dimension behavior)