### PR TITLE
Update macOS release job to use matrix strategy for architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: vcpkg-${{ runner.os }}-${{ hashFiles('build_macos.sh') }}
-          restore-keys: vcpkg-${{ runner.os }}-
+          key: vcpkg-${{ runner.os }}-${{ matrix.vcpkg_triplet }}-${{ hashFiles('build_macos.sh') }}
+          restore-keys: vcpkg-${{ runner.os }}-${{ matrix.vcpkg_triplet }}-
 
       - name: Install vcpkg packages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,29 +228,27 @@ jobs:
           path: dynamic-neural-field-composer-${{ github.ref_name }}-linux-x64.tar.gz
 
   release-macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+            vcpkg_triplet: arm64-osx
+          - os: macos-13
+            arch: x64
+            vcpkg_triplet: x64-osx
 
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.vcpkg_triplet }}
       IPK_INSTALL_PREFIX: ${{ github.workspace }}/imgui-platform-kit-install
       INSTALL_PREFIX: ${{ github.workspace }}/install
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      # ── Detect architecture and set vcpkg triplet ──────────────────────────
-      - name: Set vcpkg triplet
-        id: arch
-        run: |
-          ARCH=$(uname -m)
-          if [ "$ARCH" = "arm64" ]; then
-            echo "VCPKG_DEFAULT_TRIPLET=arm64-osx" >> "$GITHUB_ENV"
-            echo "macos_arch=arm64" >> "$GITHUB_OUTPUT"
-          else
-            echo "VCPKG_DEFAULT_TRIPLET=x64-osx" >> "$GITHUB_ENV"
-            echo "macos_arch=x64" >> "$GITHUB_OUTPUT"
-          fi
 
       # ── vcpkg ─────────────────────────────────────────────────────────────
       - name: Clone vcpkg
@@ -324,14 +322,14 @@ jobs:
       - name: Create release archive
         run: |
           cd $INSTALL_PREFIX
-          tar -czf ${{ github.workspace }}/dynamic-neural-field-composer-${{ github.ref_name }}-macos-${{ steps.arch.outputs.macos_arch }}.tar.gz .
+          tar -czf ${{ github.workspace }}/dynamic-neural-field-composer-${{ github.ref_name }}-macos-${{ matrix.arch }}.tar.gz .
 
       # ── Upload artifact for release job ───────────────────────────────────
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos-${{ steps.arch.outputs.macos_arch }}
-          path: dynamic-neural-field-composer-${{ github.ref_name }}-macos-${{ steps.arch.outputs.macos_arch }}.tar.gz
+          name: macos-${{ matrix.arch }}
+          path: dynamic-neural-field-composer-${{ github.ref_name }}-macos-${{ matrix.arch }}.tar.gz
 
   # ── GitHub Release (after all builds succeed) ──────────────────────────
   create-release:


### PR DESCRIPTION
# What and why

Add contributor infrastructure, automated static analysis, and a missing macOS release target.

## Contributing docs and templates

- CONTRIBUTING.md — dev setup, code style (Clean Code principles), test/Doxygen/wiki expectations, PR checklist, and release process
- Bug report and feature request issue templates under .github/ISSUE_TEMPLATE/
- PR template at .github/pull_request_template.md
- README updated to point to CONTRIBUTING.md and show the new Static Analysis badge

## clang-tidy static analysis

- New .github/workflows/static-analysis.yml — dedicated CI job that configures the project with -CMAKE_EXPORT_COMPILE_COMMANDS=ON and runs run-clang-tidy across all source files on Ubuntu
.clang-tidy at repo root — enables bugprone-*, modernize-*, readability-*, clang-analyzer-*, and performance-*; WarningsAsErrors left empty so pre-existing violations are reported without blocking CI
- CMAKE_EXPORT_COMPILE_COMMANDS ON added to CMakeLists.txt (no-op on MSVC, produces compile_commands.json on Unix)
- PVS-Studio license header comments removed from all 33 .cpp files under src/

## macOS Intel release

- release.yml release-macos job converted to a matrix over macos-latest (arm64) and macos-13 (x64), producing both macos-arm64.tar.gz and macos-x64.tar.gz — matching what the release notes already described but was never actually built

## How to verify

- Push a v*.*.* tag and confirm the release has both macos-arm64 and macos-x64 archives
- Check the Static Analysis workflow runs on the PR and appears green in the badge
- grep -r "PVS-Studio" dynamic-neural-field-composer/src/ returns no matches
- Open a new issue on GitHub and confirm both templates appear as options