### PR TITLE
feat: add CorrelatedNormalNoise element and AbsSigmoid activation function

### DIFF
--- a/dynamic-neural-field-composer/CMakeLists.txt
+++ b/dynamic-neural-field-composer/CMakeLists.txt
@@ -257,7 +257,6 @@ install(FILES ${simulation_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/
 install(FILES ${visualization_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/visualization)
 install(FILES ${application_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/application)
 install(FILES ${elements_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/elements)
-install(FILES "include/elements/correlated_normal_noise.h" DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/elements)
 install(FILES ${tools_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/tools)
 install(FILES ${exceptions_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/exceptions)
 install(FILES ${user_interface_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/user_interface)

--- a/dynamic-neural-field-composer/CMakeLists.txt
+++ b/dynamic-neural-field-composer/CMakeLists.txt
@@ -81,6 +81,7 @@ set(elements_headers
         "include/elements/asymmetric_gauss_kernel.h"
         "include/elements/boost_stimulus.h"
         "include/elements/memory_trace.h"
+        "include/elements/correlated_normal_noise.h"
 )
 set(element_parameters_headers
         "include/element_parameters/element_parameters.h"
@@ -161,6 +162,7 @@ set(src
         "src/elements/asymmetric_gauss_kernel.cpp"
         "src/elements/boost_stimulus.cpp"
         "src/elements/memory_trace.cpp"
+        "src/elements/correlated_normal_noise.cpp"
 
         "src/element_parameters/element_parameters.cpp"
 #"src/element_parameters/field_coupling_parameters.cpp"
@@ -255,6 +257,7 @@ install(FILES ${simulation_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/
 install(FILES ${visualization_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/visualization)
 install(FILES ${application_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/application)
 install(FILES ${elements_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/elements)
+install(FILES "include/elements/correlated_normal_noise.h" DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/elements)
 install(FILES ${tools_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/tools)
 install(FILES ${exceptions_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/exceptions)
 install(FILES ${user_interface_headers} DESTINATION ${DNF_COMPOSER_INC_INSTALL_DIR}/dnf_composer/user_interface)
@@ -361,6 +364,7 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "tests/elements/test_kernel_cross_dimension.cpp"
             "tests/elements/test_neural_field.cpp"
             "tests/elements/test_normal_noise.cpp"
+            "tests/elements/test_correlated_normal_noise.cpp"
             "tests/elements/test_boost_stimulus.cpp"
             "tests/elements/test_memory_trace.cpp"
             "tests/elements/test_change_dimensions.cpp"

--- a/dynamic-neural-field-composer/include/element_parameters/element_parameters.h
+++ b/dynamic-neural-field-composer/include/element_parameters/element_parameters.h
@@ -17,18 +17,19 @@ namespace dnf_composer
 		/// @ingroup element_parameters
 		enum ElementLabel : int
 		{
-			UNINITIALIZED,           ///< Default / not yet assigned.
-			NEURAL_FIELD,            ///< NeuralField.
-			GAUSS_STIMULUS,          ///< GaussStimulus.
-			BOOST_STIMULUS,          ///< BoostStimulus.
-			GAUSS_KERNEL,            ///< GaussKernel.
-			MEXICAN_HAT_KERNEL,      ///< MexicanHatKernel.
-			OSCILLATORY_KERNEL,      ///< OscillatoryKernel.
-			ASYMMETRIC_GAUSS_KERNEL, ///< AsymmetricGaussKernel.
-			NORMAL_NOISE,            ///< NormalNoise.
-			FIELD_COUPLING,          ///< FieldCoupling.
-			GAUSS_FIELD_COUPLING,    ///< GaussFieldCoupling.
-			MEMORY_TRACE,            ///< MemoryTrace.
+			UNINITIALIZED,              ///< Default / not yet assigned.
+			NEURAL_FIELD,               ///< NeuralField.
+			GAUSS_STIMULUS,             ///< GaussStimulus.
+			BOOST_STIMULUS,             ///< BoostStimulus.
+			GAUSS_KERNEL,               ///< GaussKernel.
+			MEXICAN_HAT_KERNEL,         ///< MexicanHatKernel.
+			OSCILLATORY_KERNEL,         ///< OscillatoryKernel.
+			ASYMMETRIC_GAUSS_KERNEL,    ///< AsymmetricGaussKernel.
+			NORMAL_NOISE,               ///< NormalNoise.
+			CORRELATED_NORMAL_NOISE,    ///< CorrelatedNormalNoise (spatially correlated, cedar-compatible).
+			FIELD_COUPLING,             ///< FieldCoupling.
+			GAUSS_FIELD_COUPLING,       ///< GaussFieldCoupling.
+			MEMORY_TRACE,               ///< MemoryTrace.
 		};
 
 		inline const std::map<ElementLabel, std::string> ElementLabelToString = {
@@ -43,6 +44,7 @@ namespace dnf_composer
 			{OSCILLATORY_KERNEL, "oscillatory kernel"},
 			{ASYMMETRIC_GAUSS_KERNEL, "asymmetric gauss kernel"},
 			{NORMAL_NOISE, "normal noise" },
+			{CORRELATED_NORMAL_NOISE, "correlated normal noise" },
 			{MEMORY_TRACE, "memory trace" },
 		};
 

--- a/dynamic-neural-field-composer/include/elements/activation_function.h
+++ b/dynamic-neural-field-composer/include/elements/activation_function.h
@@ -11,10 +11,20 @@
 
 namespace dnf_composer::element
 {
+	/// @brief Identifies the concrete activation function type.
+	///
+	/// Cross-framework naming:
+	/// | dnf-composer      | cedar             | cosivina  |
+	/// |-------------------|-------------------|-----------|
+	/// | SIGMOID           | ExpSigmoid        | sigmoid   |
+	/// | ABSSIGMOID        | AbsSigmoid        | —         |
+	/// | HEAVISIDE         | HeavisideSigmoid  | —         |
+	/// @ingroup activation_functions
 	enum ActivationFunctionType : int
 	{
-		SIGMOID,    ///< Logistic sigmoid.
-		HEAVISIDE,  ///< Binary step function.
+		SIGMOID,     ///< Logistic (exponential) sigmoid.
+		HEAVISIDE,   ///< Binary step function.
+		ABSSIGMOID,  ///< Rational (absolute-value) sigmoid approximation — cedar's default.
 	};
 
 	/// @brief Abstract base for activation functions applied to a neural field.
@@ -39,12 +49,23 @@ namespace dnf_composer::element
 		virtual ~ActivationFunction() = default;
 	};
 
-	/// @brief Logistic sigmoid: output = 1 / (1 + exp(-steepness * (x - x_shift))).
+	/// @brief Logistic (exponential) sigmoid.
+	///
+	/// Formula: @f$ \sigma(x) = \frac{1}{1 + e^{-\mathrm{steepness}(x - x\_shift)}} @f$
+	///
+	/// **Cross-framework equivalence (formula-identical):**
+	/// | Framework   | Type / call                               |
+	/// |-------------|-------------------------------------------|
+	/// | dnf-composer | `SigmoidFunction(x_shift, steepness)`    |
+	/// | cedar        | `ExpSigmoid(beta=steepness, theta=x_shift)` |
+	/// | cosivina     | `sigmoid(beta=steepness, x0=x_shift)`     |
+	///
+	/// All three use the same formula. Only the parameter names differ.
 	/// @ingroup activation_functions
 	struct SigmoidFunction final : public ActivationFunction
 	{
-		double x_shift;   ///< Inflection point of the sigmoid.
-		double steepness; ///< Slope at the inflection point.
+		double x_shift;   ///< Inflection point of the sigmoid (cedar: theta; cosivina: x0).
+		double steepness; ///< Slope at the inflection point (cedar/cosivina: beta).
 
 		SigmoidFunction(const SigmoidFunction&) = default;
 
@@ -65,11 +86,20 @@ namespace dnf_composer::element
 		~SigmoidFunction() override = default;
 	};
 
-	/// @brief Heaviside step function: output = (x >= x_shift) ? 1 : 0.
+	/// @brief Heaviside step function.
+	///
+	/// Formula: @f$ \sigma(x) = \begin{cases} 1 & x > x\_shift \\ 0 & x \le x\_shift \end{cases} @f$
+	///
+	/// **Cross-framework equivalence:**
+	/// | Framework   | Type / call                          | Note                          |
+	/// |-------------|--------------------------------------|-------------------------------|
+	/// | dnf-composer | `HeavisideFunction(x_shift)`        | maps 1 when x > x_shift       |
+	/// | cedar        | `HeavisideSigmoid(theta=x_shift)`   | identical formula (strict >)  |
+	/// | cosivina     | no built-in equivalent              | —                             |
 	/// @ingroup activation_functions
 	struct HeavisideFunction final : public ActivationFunction
 	{
-		double x_shift; ///< Threshold; activation at or above this value maps to 1.
+		double x_shift; ///< Threshold; activation strictly above this value maps to 1.
 
 		HeavisideFunction(const HeavisideFunction&) = default;
 
@@ -86,5 +116,50 @@ namespace dnf_composer::element
 		[[nodiscard]] double getXShift() const;
 
 		~HeavisideFunction() override = default;
+	};
+
+	/// @brief Rational (absolute-value) sigmoid — cedar's default activation function.
+	///
+	/// Formula: @f$ \sigma(x) = \frac{1}{2}\left(1 + \frac{\beta(x - x\_shift)}{1 + \beta|x - x\_shift|}\right) @f$
+	///
+	/// This is computationally cheaper than SigmoidFunction because it avoids `std::exp`.
+	/// At @f$\beta \ge 20@f$ the two functions are numerically indistinguishable
+	/// (max pointwise error < 0.001).
+	///
+	/// **Cross-framework equivalence:**
+	/// | Framework   | Type / call                                  | Exact? |
+	/// |-------------|----------------------------------------------|--------|
+	/// | dnf-composer | `AbsSigmoidFunction(x_shift, beta)`         | ✓      |
+	/// | cedar        | `AbsSigmoid(beta=beta, theta=x_shift)`      | ✓      |
+	/// | cosivina     | no built-in equivalent                      | —      |
+	///
+	/// **Approximate equivalence to ExpSigmoid:** Use `SigmoidFunction(x_shift, beta)` or
+	/// cosivina `sigmoid(beta=beta, x0=x_shift)` — identical for @f$\beta \ge 20@f$.
+	///
+	/// @note Cedar uses AbsSigmoid with @f$\beta = 100@f$ by default (near-Heaviside).
+	///       Published cedar parameter sets assume this steep nonlinearity.
+	/// @ingroup activation_functions
+	struct AbsSigmoidFunction final : public ActivationFunction
+	{
+		double x_shift; ///< Inflection point / threshold (cedar: theta).
+		double beta;    ///< Steepness parameter — cedar/cosivina naming (larger = steeper).
+
+		AbsSigmoidFunction(const AbsSigmoidFunction&) = default;
+
+		/// @brief Construct an AbsSigmoid with the given threshold and steepness.
+		/// @param x_shift  Inflection point of the sigmoid.
+		/// @param beta     Slope parameter.
+		AbsSigmoidFunction(double x_shift, double beta);
+
+		std::vector<double> operator()(const std::vector<double>& input) override;
+		bool operator==(const AbsSigmoidFunction& other) const;
+		[[nodiscard]] std::unique_ptr<ActivationFunction> clone() const override;
+		[[nodiscard]] std::string toString() const override;
+		void print() const override;
+
+		[[nodiscard]] double getBeta() const;
+		[[nodiscard]] double getXShift() const;
+
+		~AbsSigmoidFunction() override = default;
 	};
 }

--- a/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
+++ b/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
@@ -1,0 +1,92 @@
+#pragma once
+
+
+
+
+#include "tools/math.h"
+#include "element.h"
+
+namespace dnf_composer::element
+{
+	/// @brief Parameters for a spatially correlated Gaussian noise source.
+	///
+	/// Implements the spatially correlated noise available in cedar's NeuralField.
+	/// White Gaussian noise is convolved with a Gaussian kernel of the given @c width
+	/// to produce spatially smooth noise, then scaled by @f$ \text{amplitude} / \sqrt{\Delta t} @f$.
+	///
+	/// **Cross-framework equivalence:**
+	/// | Framework    | Equivalent feature                                              |
+	/// |--------------|------------------------------------------------------------------|
+	/// | dnf-composer | `CorrelatedNormalNoise(amplitude, width)` element               |
+	/// | cedar        | NeuralField `NoiseCorrelationKernel` (amplitude + sigma)        |
+	/// | cosivina     | no built-in equivalent                                          |
+	///
+	/// @note For uncorrelated noise (width → 0), use NormalNoise instead.
+	/// @ingroup elements
+	struct CorrelatedNormalNoiseParameters final : ElementSpecificParameters
+	{
+		double amplitude; ///< Noise amplitude (standard deviation before convolution). Default 0.05.
+		double width;     ///< Standard deviation of the Gaussian correlation kernel (in field units). Default 1.0.
+		bool circular;    ///< Use circular (toroidal) boundary for convolution. Default true.
+
+		/// @brief Construct CorrelatedNormalNoise parameters.
+		/// @param amplitude  Noise amplitude. Default 0.05.
+		/// @param width      Spatial correlation width (sigma of the Gaussian kernel). Default 1.0.
+		/// @param circular   Circular boundary for convolution. Default true.
+		explicit CorrelatedNormalNoiseParameters(double amplitude = 0.05,
+		                                         double width = 1.0,
+		                                         bool circular = true)
+			: amplitude(amplitude), width(width), circular(circular)
+		{}
+
+		bool operator==(const CorrelatedNormalNoiseParameters& other) const
+		{
+			constexpr double epsilon = 1e-6;
+			return std::abs(amplitude - other.amplitude) < epsilon &&
+			       std::abs(width - other.width) < epsilon &&
+			       circular == other.circular;
+		}
+
+		[[nodiscard]] std::string toString() const override
+		{
+			std::ostringstream result;
+			result << "Parameters: ["
+			       << "Amplitude: " << std::fixed << std::setprecision(4) << amplitude << ", "
+			       << "Width: " << std::fixed << std::setprecision(2) << width << ", "
+			       << "Circular: " << (circular ? "true" : "false") << "]";
+			return result.str();
+		}
+	};
+
+	/// @brief Spatially correlated Gaussian noise source — cedar-compatible.
+	///
+	/// Each @c step() draws white Gaussian noise, convolves it with a normalised
+	/// Gaussian of the configured @c width, and scales by
+	/// @f$ \text{amplitude} / \sqrt{\Delta t} @f$ to maintain correct stochastic
+	/// scaling regardless of integration step size.
+	///
+	/// Connect the output of this element to a NeuralField as you would NormalNoise.
+	///
+	/// @ingroup elements
+	class CorrelatedNormalNoise final : public Element
+	{
+	private:
+		CorrelatedNormalNoiseParameters parameters;
+		std::vector<double> correlationKernel; ///< Precomputed normalised Gaussian kernel.
+		std::vector<int> extIndex;             ///< Extended index for circular convolution.
+	public:
+		/// @brief Construct a CorrelatedNormalNoise element.
+		/// @param elementCommonParameters  Name, label, and spatial dimensions.
+		/// @param parameters               Noise-specific parameters.
+		CorrelatedNormalNoise(const ElementCommonParameters& elementCommonParameters,
+		                      const CorrelatedNormalNoiseParameters& parameters);
+
+		void init() override;
+		void step(double t, double deltaT) override;
+		std::shared_ptr<Element> clone() const override;
+		std::string toString() const override;
+
+		void setParameters(const CorrelatedNormalNoiseParameters& parameters);
+		CorrelatedNormalNoiseParameters getParameters() const;
+	};
+}

--- a/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
+++ b/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
@@ -26,7 +26,7 @@ namespace dnf_composer::element
 	struct CorrelatedNormalNoiseParameters final : ElementSpecificParameters
 	{
 		double amplitude; ///< Noise amplitude (standard deviation before convolution). Default 0.05.
-		double width;     ///< Standard deviation of the Gaussian correlation kernel (in field units). Default 1.0.
+		double width;     ///< Standard deviation of the Gaussian correlation kernel (in samples/indices). Default 1.0.
 		bool circular;    ///< Use circular (toroidal) boundary for convolution. Default true.
 
 		/// @brief Construct CorrelatedNormalNoise parameters.

--- a/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
+++ b/dynamic-neural-field-composer/include/elements/correlated_normal_noise.h
@@ -79,7 +79,7 @@ namespace dnf_composer::element
 		/// @param elementCommonParameters  Name, label, and spatial dimensions.
 		/// @param parameters               Noise-specific parameters.
 		CorrelatedNormalNoise(const ElementCommonParameters& elementCommonParameters,
-		                      const CorrelatedNormalNoiseParameters& parameters);
+		                      CorrelatedNormalNoiseParameters  parameters);
 
 		void init() override;
 		void step(double t, double deltaT) override;

--- a/dynamic-neural-field-composer/include/elements/element_factory.h
+++ b/dynamic-neural-field-composer/include/elements/element_factory.h
@@ -6,6 +6,7 @@
 #include "elements/mexican_hat_kernel.h"
 #include "elements/neural_field.h"
 #include "elements/normal_noise.h"
+#include "elements/correlated_normal_noise.h"
 #include "elements/gauss_field_coupling.h"
 #include "elements/field_coupling.h"
 #include "simulation/simulation.h"

--- a/dynamic-neural-field-composer/include/elements/neural_field.h
+++ b/dynamic-neural-field-composer/include/elements/neural_field.h
@@ -11,8 +11,8 @@ namespace dnf_composer::element
 	/// @ingroup elements
 	struct NeuralFieldParameters final : ElementSpecificParameters
 	{
-		double tau;                                        ///< Time constant of the field's relaxation dynamics.
-		double startingRestingLevel;                       ///< Homogeneous resting level (h); sub-threshold when negative.
+		double tau;                                             ///< Time constant of the field's relaxation dynamics.
+		double startingRestingLevel;                            ///< Homogeneous resting level (h); sub-threshold when negative.
 		std::unique_ptr<ActivationFunction> activationFunction; ///< Nonlinearity applied to activation to produce output.
 
 		NeuralFieldParameters& operator=(const NeuralFieldParameters& other)
@@ -39,12 +39,12 @@ namespace dnf_composer::element
 
 		/// @brief Default constructor: tau=25, restingLevel=-5, sigmoid(0, 10).
 		NeuralFieldParameters()
-			:tau(25.0), startingRestingLevel(-5.0), activationFunction(nullptr)
+			: tau(25.0), startingRestingLevel(-5.0), activationFunction(nullptr)
 		{}
 
 		/// @brief Construct with explicit tau, resting level, and activation function.
-		/// @param tau             Time constant in ms.
-		/// @param restingLevel    Homogeneous resting level h.
+		/// @param tau                 Time constant in ms.
+		/// @param restingLevel        Homogeneous resting level h.
 		/// @param activationFunction  Pointwise nonlinearity.
 		NeuralFieldParameters(double tau, double restingLevel,
 		                      const ActivationFunction& activationFunction)

--- a/dynamic-neural-field-composer/include/simulation/simulation_file_manager.h
+++ b/dynamic-neural-field-composer/include/simulation/simulation_file_manager.h
@@ -10,6 +10,7 @@
 #include "elements/gauss_kernel.h"
 #include "elements/mexican_hat_kernel.h"
 #include "elements/normal_noise.h"
+#include "elements/correlated_normal_noise.h"
 #include "elements/field_coupling.h"
 #include "elements/gauss_stimulus.h"
 #include "elements/gauss_field_coupling.h"

--- a/dynamic-neural-field-composer/include/tools/math.h
+++ b/dynamic-neural-field-composer/include/tools/math.h
@@ -226,6 +226,23 @@ namespace dnf_composer::tools::math
 		return s;
 	}
 
+	/// @brief AbsSigmoid: rational approximation of the logistic sigmoid.
+	///
+	/// Formula: s(x) = 0.5 * (1 + beta * (x - x0) / (1 + beta * |x - x0|))
+	///
+	/// Equivalent to cedar's AbsSigmoid(beta, theta=x0). At beta >= 20 virtually
+	/// indistinguishable from the ExpSigmoid but avoids std::exp() entirely.
+	template <typename T>
+	std::vector<T> absSigmoid(const std::vector<T>& x, T beta, T x0)
+	{
+		std::vector<T> s(x.size());
+		for (std::size_t i = 0; i < s.size(); ++i) {
+			const T diff = x[i] - x0;
+			s[i] = static_cast<T>(0.5) * (1 + beta * diff / (1 + beta * std::abs(diff)));
+		}
+		return s;
+	}
+
 	template<typename T>
 	std::vector<T> heaviside(const std::vector<T>& x, T threshold)
 	{

--- a/dynamic-neural-field-composer/include/user_interface/element_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/element_window.h
@@ -13,6 +13,7 @@
 #include "elements/gauss_kernel.h"
 #include "elements/mexican_hat_kernel.h"
 #include "elements/normal_noise.h"
+#include "elements/correlated_normal_noise.h"
 #include "elements/gauss_field_coupling.h"
 #include "elements/oscillatory_kernel.h"
 #include "elements/asymmetric_gauss_kernel.h"
@@ -62,6 +63,7 @@ namespace dnf_composer::user_interface
 		static void modifyElementGaussKernel(const std::shared_ptr<element::Element>& element);
 		static void modifyElementMexicanHatKernel(const std::shared_ptr<element::Element>& element);
 		static void modifyElementNormalNoise(const std::shared_ptr<element::Element>& element);
+		static void modifyElementCorrelatedNormalNoise(const std::shared_ptr<element::Element>& element);
 		static void modifyElementGaussFieldCoupling(const std::shared_ptr<element::Element>& element);
 		static void modifyElementOscillatoryKernel(const std::shared_ptr<element::Element>& element);
 		static void modifyElementAsymmetricGaussKernel(const std::shared_ptr<element::Element>& element);

--- a/dynamic-neural-field-composer/include/user_interface/node_graph_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/node_graph_window.h
@@ -10,6 +10,7 @@
 #include "elements/gauss_stimulus.h"
 #include "elements/neural_field.h"
 #include "elements/normal_noise.h"
+#include "elements/correlated_normal_noise.h"
 #include "elements/mexican_hat_kernel.h"
 #include "elements/gauss_field_coupling.h"
 #include "elements/field_coupling.h"
@@ -33,6 +34,8 @@ namespace dnf_composer::user_interface
 			return IM_COL32(86, 128, 191, 255);   // Soft Blue
 		case element::ElementLabel::NORMAL_NOISE:
 			return IM_COL32(223, 148, 84, 255);   // Warm Orange
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+			return IM_COL32(210, 110, 60, 255);   // Deep Orange
 		case element::ElementLabel::GAUSS_KERNEL:
 			return IM_COL32(191, 63, 63, 255);    // Muted Red
 		case element::ElementLabel::GAUSS_STIMULUS:

--- a/dynamic-neural-field-composer/include/user_interface/simulation_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/simulation_window.h
@@ -69,6 +69,7 @@ namespace dnf_composer::user_interface
 		void addElementGaussKernel() const;
 		void addElementMexicanHatKernel() const;
 		void addElementNormalNoise() const;
+		void addElementCorrelatedNormalNoise() const;
 		void addElementGaussFieldCoupling() const;
 	};
 }

--- a/dynamic-neural-field-composer/src/elements/activation_function.cpp
+++ b/dynamic-neural-field-composer/src/elements/activation_function.cpp
@@ -92,4 +92,53 @@ namespace dnf_composer::element
 	{
 		return x_shift;
 	}
+
+	AbsSigmoidFunction::AbsSigmoidFunction(const double x_shift, const double beta)
+		: x_shift(x_shift), beta(beta)
+	{
+		type = ActivationFunctionType::ABSSIGMOID;
+	}
+
+	std::vector<double> AbsSigmoidFunction::operator()(const std::vector<double>& input)
+	{
+		return tools::math::absSigmoid(input, beta, x_shift);
+	}
+
+	bool AbsSigmoidFunction::operator==(const AbsSigmoidFunction& other) const
+	{
+		return x_shift == other.x_shift && beta == other.beta;
+	}
+
+	std::unique_ptr<ActivationFunction> AbsSigmoidFunction::clone() const
+	{
+		return std::make_unique<AbsSigmoidFunction>(*this);
+	}
+
+	std::string AbsSigmoidFunction::toString() const
+	{
+		std::string result = "AbsSigmoidFunction(";
+		std::ostringstream stream_x_shift;
+		stream_x_shift << std::fixed << std::setprecision(2) << x_shift;
+		result += "x_shift = " + stream_x_shift.str() + ", ";
+		std::ostringstream stream_beta;
+		stream_beta << std::fixed << std::setprecision(2) << beta;
+		result += "beta = " + stream_beta.str() + ")";
+		return result;
+	}
+
+	void AbsSigmoidFunction::print() const
+	{
+		const std::string result = toString();
+		tools::logger::log(tools::logger::LogLevel::INFO, result);
+	}
+
+	double AbsSigmoidFunction::getBeta() const
+	{
+		return beta;
+	}
+
+	double AbsSigmoidFunction::getXShift() const
+	{
+		return x_shift;
+	}
 }

--- a/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
+++ b/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
@@ -1,0 +1,94 @@
+#include "elements/correlated_normal_noise.h"
+
+//https://github.com/stevenlovegrove/Pangolin/issues/352
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
+namespace dnf_composer::element
+{
+	CorrelatedNormalNoise::CorrelatedNormalNoise(
+		const ElementCommonParameters& elementCommonParameters,
+		const CorrelatedNormalNoiseParameters& parameters)
+		: Element(elementCommonParameters), parameters(parameters)
+	{
+		commonParameters.identifiers.label = ElementLabel::CORRELATED_NORMAL_NOISE;
+	}
+
+	void CorrelatedNormalNoise::init()
+	{
+		std::ranges::fill(components["output"], 0.0);
+
+		const int fieldSize = commonParameters.dimensionParameters.size;
+
+		// Build a normalised Gaussian kernel for spatial correlation.
+		// Kernel half-width: 5 * sigma (matches GaussKernel cutoff convention).
+		const int halfWidth = std::max(1, static_cast<int>(5.0 * parameters.width));
+		const int kernelSize = 2 * halfWidth + 1;
+
+		std::vector<int> rangeX(kernelSize);
+		std::iota(rangeX.begin(), rangeX.end(), -halfWidth);
+		correlationKernel = tools::math::gaussNorm(rangeX, 0.0, parameters.width);
+
+		// Precompute circular extension index for wrap-around convolution.
+		if (parameters.circular)
+		{
+			const std::array<int, 2> kernelRange = { halfWidth, halfWidth };
+			extIndex = tools::math::createExtendedIndex(fieldSize, kernelRange);
+		}
+		else
+		{
+			extIndex.clear();
+		}
+	}
+
+	void CorrelatedNormalNoise::step(double t, double deltaT)
+	{
+		const int fieldSize = commonParameters.dimensionParameters.size;
+		const std::vector<double> whiteNoise = tools::math::generateNormalVector(fieldSize);
+
+		std::vector<double> smoothed;
+		if (parameters.circular && !extIndex.empty())
+		{
+			const auto extended = tools::math::obtainCircularVector(extIndex, whiteNoise);
+			smoothed = tools::math::conv_valid(extended, correlationKernel);
+		}
+		else
+		{
+			smoothed = tools::math::conv_same(whiteNoise, correlationKernel);
+		}
+
+		const double scale = parameters.amplitude / std::sqrt(deltaT);
+		for (int i = 0; i < fieldSize; i++)
+			components["output"][i] = scale * smoothed[i];
+	}
+
+	std::shared_ptr<Element> CorrelatedNormalNoise::clone() const
+	{
+		return std::make_shared<CorrelatedNormalNoise>(*this);
+	}
+
+	std::string CorrelatedNormalNoise::toString() const
+	{
+		std::string result;
+		result += "Correlated normal noise element\n";
+		result += commonParameters.toString() + '\n';
+		result += parameters.toString();
+		return result;
+	}
+
+	void CorrelatedNormalNoise::setParameters(const CorrelatedNormalNoiseParameters& p)
+	{
+		parameters = p;
+		init();
+	}
+
+	CorrelatedNormalNoiseParameters CorrelatedNormalNoise::getParameters() const
+	{
+		return parameters;
+	}
+}

--- a/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
+++ b/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
@@ -29,12 +29,13 @@ namespace dnf_composer::element
 
 		// Build a normalized Gaussian kernel for spatial correlation.
 		// Kernel half-width: 5 * sigma (matches GaussKernel cutoff convention).
-		const int halfWidth = std::max(1, static_cast<int>(5.0 * parameters.width));
+		const double effectiveWidth = std::max(parameters.width, 1e-3);
+		const int halfWidth = std::max(1, static_cast<int>(5.0 * effectiveWidth));
 		const int kernelSize = (2 * halfWidth) + 1;
 
 		std::vector<int> rangeX(kernelSize);
 		std::iota(rangeX.begin(), rangeX.end(), -halfWidth);
-		correlationKernel = tools::math::gaussNorm(rangeX, 0.0, parameters.width);
+		correlationKernel = tools::math::gaussNorm(rangeX, 0.0, effectiveWidth);
 
 		// Precompute circular extension index for wrap-around convolution.
 		if (parameters.circular)

--- a/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
+++ b/dynamic-neural-field-composer/src/elements/correlated_normal_noise.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "elements/correlated_normal_noise.h"
 
 //https://github.com/stevenlovegrove/Pangolin/issues/352
@@ -13,8 +15,8 @@ namespace dnf_composer::element
 {
 	CorrelatedNormalNoise::CorrelatedNormalNoise(
 		const ElementCommonParameters& elementCommonParameters,
-		const CorrelatedNormalNoiseParameters& parameters)
-		: Element(elementCommonParameters), parameters(parameters)
+		CorrelatedNormalNoiseParameters  parameters)
+		: Element(elementCommonParameters), parameters(std::move(parameters))
 	{
 		commonParameters.identifiers.label = ElementLabel::CORRELATED_NORMAL_NOISE;
 	}
@@ -25,10 +27,10 @@ namespace dnf_composer::element
 
 		const int fieldSize = commonParameters.dimensionParameters.size;
 
-		// Build a normalised Gaussian kernel for spatial correlation.
+		// Build a normalized Gaussian kernel for spatial correlation.
 		// Kernel half-width: 5 * sigma (matches GaussKernel cutoff convention).
 		const int halfWidth = std::max(1, static_cast<int>(5.0 * parameters.width));
-		const int kernelSize = 2 * halfWidth + 1;
+		const int kernelSize = (2 * halfWidth) + 1;
 
 		std::vector<int> rangeX(kernelSize);
 		std::iota(rangeX.begin(), rangeX.end(), -halfWidth);
@@ -63,8 +65,9 @@ namespace dnf_composer::element
 		}
 
 		const double scale = parameters.amplitude / std::sqrt(deltaT);
-		for (int i = 0; i < fieldSize; i++)
+		for (int i = 0; i < fieldSize; i++) {
 			components["output"][i] = scale * smoothed[i];
+		}
 	}
 
 	std::shared_ptr<Element> CorrelatedNormalNoise::clone() const

--- a/dynamic-neural-field-composer/src/elements/element_factory.cpp
+++ b/dynamic-neural-field-composer/src/elements/element_factory.cpp
@@ -43,6 +43,12 @@ namespace dnf_composer
 					return std::make_shared<NormalNoise>(elementCommonParameters, *params);
 				};
 
+			elementCreators[ElementLabel::CORRELATED_NORMAL_NOISE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
+				{
+					const auto params = dynamic_cast<const CorrelatedNormalNoiseParameters*>(&elementSpecificParameters);
+					return std::make_shared<CorrelatedNormalNoise>(elementCommonParameters, *params);
+				};
+
 			elementCreators[ElementLabel::GAUSS_FIELD_COUPLING] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
 					const auto params = dynamic_cast<const GaussFieldCouplingParameters*>(&elementSpecificParameters);
@@ -109,6 +115,8 @@ namespace dnf_composer
 						return creator->second(ElementCommonParameters(type), MexicanHatKernelParameters());
 					case ElementLabel::NORMAL_NOISE:
 						return creator->second(ElementCommonParameters(type), NormalNoiseParameters());
+					case ElementLabel::CORRELATED_NORMAL_NOISE:
+						return creator->second(ElementCommonParameters(type), CorrelatedNormalNoiseParameters());
 					case ElementLabel::GAUSS_FIELD_COUPLING:
 						return creator->second(ElementCommonParameters(type), GaussFieldCouplingParameters());
 					case ElementLabel::FIELD_COUPLING:

--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -166,6 +166,18 @@ namespace dnf_composer
                 }
             }
             break;
+            case element::ActivationFunctionType::ABSSIGMOID:
+            {
+                const auto absSigmoidFn = dynamic_cast<const element::AbsSigmoidFunction*>(neuralFieldParameters.activationFunction.get());
+                if (absSigmoidFn) {
+                    elementJson["activationFunction"] = {
+                        {"type", "abs_sigmoid"},
+                        {"x_shift", absSigmoidFn->getXShift()},
+                        {"beta", absSigmoidFn->getBeta()},
+                    };
+                }
+            }
+            break;
             }
         }
         break;
@@ -198,6 +210,15 @@ namespace dnf_composer
             const auto normalNoise = std::dynamic_pointer_cast<element::NormalNoise>(element);
             const auto normalNoiseParameters = normalNoise->getParameters();
             elementJson["amplitude"] = normalNoiseParameters.amplitude;
+        }
+        break;
+        case element::CORRELATED_NORMAL_NOISE:
+        {
+            const auto cnn = std::dynamic_pointer_cast<element::CorrelatedNormalNoise>(element);
+            const auto p = cnn->getParameters();
+            elementJson["amplitude"] = p.amplitude;
+            elementJson["width"] = p.width;
+            elementJson["circular"] = p.circular;
         }
         break;
         case element::GAUSS_STIMULUS:
@@ -299,33 +320,35 @@ namespace dnf_composer
 
 	        switch (elementLabel)
 	    	{
-	        case element::NEURAL_FIELD: 
+	        case element::NEURAL_FIELD:
 	            {
-		            // Parse specific parameters for neural field
 		            const double tau = elementJson["tau"];
 		            const double restingLevel = elementJson["restingLevel"];
 
-		            // Check activation function type and parameters
 		            auto activationFunctionJson = elementJson["activationFunction"];
 		            std::unique_ptr<element::ActivationFunction> activationFunction;
 		            if (!activationFunctionJson.is_null()) {
 		                std::string activationFunctionType = activationFunctionJson["type"];
 		                if (activationFunctionType == "heaviside") {
-		                    double x_shift = activationFunctionJson["x_shift"];
+		                    const double x_shift = activationFunctionJson["x_shift"];
 		                    activationFunction = std::make_unique<element::HeavisideFunction>(x_shift);
 		                }
 		                else if (activationFunctionType == "sigmoid") {
-		                    double x_shift = activationFunctionJson["x_shift"];
-		                    double steepness = activationFunctionJson["steepness"];
+		                    const double x_shift = activationFunctionJson["x_shift"];
+		                    const double steepness = activationFunctionJson["steepness"];
 		                    activationFunction = std::make_unique<element::SigmoidFunction>(x_shift, steepness);
 		                }
+		                else if (activationFunctionType == "abs_sigmoid") {
+		                    const double x_shift = activationFunctionJson["x_shift"];
+		                    const double beta = activationFunctionJson["beta"];
+		                    activationFunction = std::make_unique<element::AbsSigmoidFunction>(x_shift, beta);
+		                }
 		            }
-		            // Reconstruct neural field element
+
 		            auto neuralField = std::make_shared<element::NeuralField>(
 		                element::ElementCommonParameters(uniqueName, element::ElementDimensions(x_max, d_x)),
 		                element::NeuralFieldParameters(tau, restingLevel, *activationFunction)
 		            );
-		            // Add the reconstructed element to the simulation
 		            simulation->addElement(neuralField);
 		        }
 	        	break;
@@ -338,6 +361,19 @@ namespace dnf_composer
                     element::NormalNoiseParameters(amplitude)
                 );
                 simulation->addElement(normalNoise);
+            }
+            break;
+            case element::CORRELATED_NORMAL_NOISE:
+            {
+                const double amplitude = elementJson["amplitude"];
+                const double width = elementJson["width"];
+                const bool circular = elementJson["circular"];
+
+                auto cnn = std::make_shared<element::CorrelatedNormalNoise>(
+                    element::ElementCommonParameters(uniqueName, element::ElementDimensions(x_max, d_x)),
+                    element::CorrelatedNormalNoiseParameters(amplitude, width, circular)
+                );
+                simulation->addElement(cnn);
             }
             break;
 	        case element::GAUSS_KERNEL:

--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -344,6 +344,8 @@ namespace dnf_composer
 		                    activationFunction = std::make_unique<element::AbsSigmoidFunction>(x_shift, beta);
 		                }
 		            }
+		            if (!activationFunction)
+		                activationFunction = std::make_unique<element::SigmoidFunction>(0.0, 10.0);
 
 		            auto neuralField = std::make_shared<element::NeuralField>(
 		                element::ElementCommonParameters(uniqueName, element::ElementDimensions(x_max, d_x)),

--- a/dynamic-neural-field-composer/src/user_interface/element_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/element_window.cpp
@@ -56,7 +56,8 @@ namespace dnf_composer::user_interface
 			switch (e->getLabel())
 			{
 				case element::ElementLabel::NORMAL_NOISE:            return h(1  + dimRows);
-				case element::ElementLabel::NEURAL_FIELD:            return h(2  + dimRows);
+				case element::ElementLabel::CORRELATED_NORMAL_NOISE: return h(2  + dimRows);
+				case element::ElementLabel::NEURAL_FIELD:            return h(5  + dimRows);
 				case element::ElementLabel::GAUSS_STIMULUS:          return h(4  + dimRows);
 				case element::ElementLabel::GAUSS_KERNEL:            return h(4  + kDimRows);
 				case element::ElementLabel::FIELD_COUPLING:          return h(7  + dimRows);
@@ -405,6 +406,9 @@ namespace dnf_composer::user_interface
 		case element::ElementLabel::NORMAL_NOISE:
 			modifyElementNormalNoise(element);
 			break;
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+			modifyElementCorrelatedNormalNoise(element);
+			break;
 		case element::ElementLabel::GAUSS_FIELD_COUPLING:
 			modifyElementGaussFieldCoupling(element);
 			break;
@@ -435,36 +439,121 @@ namespace dnf_composer::user_interface
 
 	void ElementWindow::modifyElementNeuralField(const std::shared_ptr<element::Element>& element)
 	{
-			const float ui = ImGui::GetIO().FontGlobalScale;
+		const float ui = ImGui::GetIO().FontGlobalScale;
 
-			const auto neuralField = std::dynamic_pointer_cast<element::NeuralField>(element);
-			element::NeuralFieldParameters nfp = neuralField->getParameters();
+		const auto neuralField = std::dynamic_pointer_cast<element::NeuralField>(element);
+		element::NeuralFieldParameters nfp = neuralField->getParameters();
+		bool updated = false;
 
-			auto restingLevel = static_cast<float>(nfp.startingRestingLevel);
-			auto tau = static_cast<float>(nfp.tau);
-
-			std::string label = "##" + element->getUniqueName() + "Resting level";
-			ImGui::SetNextItemWidth(150.0f * ui);
-			ImGui::DragFloat(label.c_str(), &restingLevel, 0.1f, -30.0f, 0.0f);
-			ImGui::SameLine(); ImGui::Text("Resting level");
-
-			label = "##" + element->getUniqueName() + "Tau";
-			ImGui::SetNextItemWidth(150.0f * ui);
-			ImGui::DragFloat(label.c_str(), &tau, 0.5f, 1.0f, 300.0f);
-			ImGui::SameLine(); ImGui::Text("Tau");
-
-		static constexpr double epsilon = 1e-6;
-		if (std::abs(restingLevel - static_cast<float>(nfp.startingRestingLevel)) > epsilon)
+		auto restingLevel = static_cast<float>(nfp.startingRestingLevel);
+		std::string label = "##" + element->getUniqueName() + "RestingLevel";
+		ImGui::SetNextItemWidth(150.0f * ui);
+		if (ImGui::DragFloat(label.c_str(), &restingLevel, 0.1f, -30.0f, 0.0f))
 		{
 			nfp.startingRestingLevel = restingLevel;
-			neuralField->setParameters(nfp);
+			updated = true;
 		}
+		ImGui::SameLine(); ImGui::Text("Resting level");
 
-		if (std::abs(tau - static_cast<float>(nfp.tau)) > epsilon)
+		auto tau = static_cast<float>(nfp.tau);
+		label = "##" + element->getUniqueName() + "Tau";
+		ImGui::SetNextItemWidth(150.0f * ui);
+		if (ImGui::DragFloat(label.c_str(), &tau, 0.5f, 1.0f, 300.0f))
 		{
 			nfp.tau = tau;
-			neuralField->setParameters(nfp);
+			updated = true;
 		}
+		ImGui::SameLine(); ImGui::Text("Tau");
+
+		static const char* actFnNames[] = { "Sigmoid", "Heaviside", "AbsSigmoid" };
+		int actFnType = nfp.activationFunction
+			? static_cast<int>(nfp.activationFunction->type)
+			: element::SIGMOID;
+		label = "##" + element->getUniqueName() + "ActFnType";
+		ImGui::SetNextItemWidth(150.0f * ui);
+		if (ImGui::Combo(label.c_str(), &actFnType, actFnNames, 3))
+		{
+			switch (actFnType)
+			{
+			case element::SIGMOID:    nfp.activationFunction = std::make_unique<element::SigmoidFunction>(0.0, 10.0); break;
+			case element::HEAVISIDE:  nfp.activationFunction = std::make_unique<element::HeavisideFunction>(0.0); break;
+			case element::ABSSIGMOID: nfp.activationFunction = std::make_unique<element::AbsSigmoidFunction>(0.0, 100.0); break;
+			default: break;
+			}
+			updated = true;
+		}
+		ImGui::SameLine(); ImGui::Text("Activation fn.");
+
+		if (actFnType == element::SIGMOID)
+		{
+			const auto* sig = dynamic_cast<const element::SigmoidFunction*>(nfp.activationFunction.get());
+			auto xShift    = sig ? static_cast<float>(sig->getXShift())    : 0.0f;
+			auto steepness = sig ? static_cast<float>(sig->getSteepness()) : 10.0f;
+
+			label = "##" + element->getUniqueName() + "SigXShift";
+			ImGui::SetNextItemWidth(150.0f * ui);
+			if (ImGui::DragFloat(label.c_str(), &xShift, 0.1f, -30.0f, 30.0f))
+			{
+				nfp.activationFunction = std::make_unique<element::SigmoidFunction>(
+					static_cast<double>(xShift), static_cast<double>(steepness));
+				updated = true;
+			}
+			ImGui::SameLine(); ImGui::Text("X shift");
+
+			label = "##" + element->getUniqueName() + "SigSteepness";
+			ImGui::SetNextItemWidth(150.0f * ui);
+			if (ImGui::DragFloat(label.c_str(), &steepness, 0.5f, 0.1f, 500.0f))
+			{
+				nfp.activationFunction = std::make_unique<element::SigmoidFunction>(
+					static_cast<double>(xShift), static_cast<double>(steepness));
+				updated = true;
+			}
+			ImGui::SameLine(); ImGui::Text("Steepness");
+		}
+		else if (actFnType == element::HEAVISIDE)
+		{
+			const auto* h = dynamic_cast<const element::HeavisideFunction*>(nfp.activationFunction.get());
+			auto xShift = h ? static_cast<float>(h->getXShift()) : 0.0f;
+
+			label = "##" + element->getUniqueName() + "HeavXShift";
+			ImGui::SetNextItemWidth(150.0f * ui);
+			if (ImGui::DragFloat(label.c_str(), &xShift, 0.1f, -30.0f, 30.0f))
+			{
+				nfp.activationFunction = std::make_unique<element::HeavisideFunction>(
+					static_cast<double>(xShift));
+				updated = true;
+			}
+			ImGui::SameLine(); ImGui::Text("X shift");
+		}
+		else if (actFnType == element::ABSSIGMOID)
+		{
+			const auto* abs = dynamic_cast<const element::AbsSigmoidFunction*>(nfp.activationFunction.get());
+			auto xShift = abs ? static_cast<float>(abs->getXShift()) : 0.0f;
+			auto beta   = abs ? static_cast<float>(abs->getBeta())   : 100.0f;
+
+			label = "##" + element->getUniqueName() + "AbsXShift";
+			ImGui::SetNextItemWidth(150.0f * ui);
+			if (ImGui::DragFloat(label.c_str(), &xShift, 0.1f, -30.0f, 30.0f))
+			{
+				nfp.activationFunction = std::make_unique<element::AbsSigmoidFunction>(
+					static_cast<double>(xShift), static_cast<double>(beta));
+				updated = true;
+			}
+			ImGui::SameLine(); ImGui::Text("X shift");
+
+			label = "##" + element->getUniqueName() + "AbsBeta";
+			ImGui::SetNextItemWidth(150.0f * ui);
+			if (ImGui::DragFloat(label.c_str(), &beta, 1.0f, 0.1f, 1000.0f))
+			{
+				nfp.activationFunction = std::make_unique<element::AbsSigmoidFunction>(
+					static_cast<double>(xShift), static_cast<double>(beta));
+				updated = true;
+			}
+			ImGui::SameLine(); ImGui::Text("Beta");
+		}
+
+		if (updated)
+			neuralField->setParameters(nfp);
 	}
 
 	void ElementWindow::modifyElementGaussStimulus(const std::shared_ptr<element::Element>& element)
@@ -740,6 +829,36 @@ namespace dnf_composer::user_interface
 		{
 			nnp.amplitude = amplitude;
 			normalNoise->setParameters(nnp);
+		}
+	}
+
+	void ElementWindow::modifyElementCorrelatedNormalNoise(const std::shared_ptr<element::Element>& element)
+	{
+		const float ui = ImGui::GetIO().FontGlobalScale;
+
+		const auto cnn = std::dynamic_pointer_cast<element::CorrelatedNormalNoise>(element);
+		element::CorrelatedNormalNoiseParameters p = cnn->getParameters();
+
+		auto amplitude = static_cast<float>(p.amplitude);
+		auto width = static_cast<float>(p.width);
+
+		std::string label = "##" + element->getUniqueName() + "Amplitude";
+		ImGui::SetNextItemWidth(150.0f * ui);
+		ImGui::DragFloat(label.c_str(), &amplitude, 0.001f, 0.0f, 5.0f, "%.4f");
+		ImGui::SameLine(); ImGui::Text("Amplitude");
+
+		label = "##" + element->getUniqueName() + "Width";
+		ImGui::SetNextItemWidth(150.0f * ui);
+		ImGui::DragFloat(label.c_str(), &width, 0.1f, 0.1f, 30.0f);
+		ImGui::SameLine(); ImGui::Text("Width");
+
+		static constexpr double epsilon = 1e-6;
+		if (std::abs(amplitude - static_cast<float>(p.amplitude)) > epsilon ||
+		    std::abs(width - static_cast<float>(p.width)) > epsilon)
+		{
+			p.amplitude = amplitude;
+			p.width = width;
+			cnn->setParameters(p);
 		}
 	}
 
@@ -1076,6 +1195,8 @@ namespace dnf_composer::user_interface
 			return ImVec4(0.337f, 0.502f, 0.749f, 1.0f);  // Soft Blue
 		case element::ElementLabel::NORMAL_NOISE:
 			return ImVec4(0.875f, 0.580f, 0.329f, 1.0f);  // Warm Orange
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+			return ImVec4(0.820f, 0.490f, 0.200f, 1.0f);  // Deep Orange
 		case element::ElementLabel::GAUSS_KERNEL:
 			return ImVec4(0.749f, 0.247f, 0.247f, 1.0f);  // Muted Red
 		case element::ElementLabel::GAUSS_STIMULUS:
@@ -1109,6 +1230,7 @@ namespace dnf_composer::user_interface
 		case element::ElementLabel::GAUSS_KERNEL: return "Gaussian Kernels";
 		case element::ElementLabel::MEXICAN_HAT_KERNEL: return "Mexican Hat Kernels";
 		case element::ElementLabel::NORMAL_NOISE: return "Normal Noise";
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE: return "Correlated Normal Noise";
 		case element::ElementLabel::GAUSS_FIELD_COUPLING: return "Gaussian Field Couplings";
 		case element::ElementLabel::OSCILLATORY_KERNEL: return "Oscillatory Kernels";
 		case element::ElementLabel::ASYMMETRIC_GAUSS_KERNEL: return "Asymmetric Gaussian Kernels";

--- a/dynamic-neural-field-composer/src/user_interface/element_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/element_window.cpp
@@ -843,6 +843,7 @@ namespace dnf_composer::user_interface
 
 		auto amplitude = static_cast<float>(p.amplitude);
 		auto width = static_cast<float>(p.width);
+		bool circular = p.circular;
 
 		std::string label = "##" + element->getUniqueName() + "Amplitude";
 		ImGui::SetNextItemWidth(150.0f * ui);
@@ -854,12 +855,18 @@ namespace dnf_composer::user_interface
 		ImGui::DragFloat(label.c_str(), &width, 0.1f, 0.1f, 30.0f);
 		ImGui::SameLine(); ImGui::Text("Width");
 
+		label = "##" + element->getUniqueName() + "Circular";
+		ImGui::Checkbox(label.c_str(), &circular);
+		ImGui::SameLine(); ImGui::Text("Circular");
+
 		static constexpr double epsilon = 1e-6;
 		if (std::abs(amplitude - static_cast<float>(p.amplitude)) > epsilon ||
-		    std::abs(width - static_cast<float>(p.width)) > epsilon)
+		    std::abs(width - static_cast<float>(p.width)) > epsilon ||
+		    circular != p.circular)
 		{
 			p.amplitude = amplitude;
 			p.width = width;
+			p.circular = circular;
 			cnn->setParameters(p);
 		}
 	}

--- a/dynamic-neural-field-composer/src/user_interface/element_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/element_window.cpp
@@ -19,8 +19,9 @@ namespace dnf_composer::user_interface
 		ImGui::PushFont(g_BlackLargeFont);
 		const bool open = ImGui::Begin("Element Control", nullptr, imgui_kit::getGlobalWindowFlags());
 		ImGui::PopFont();
-		if (open)
+		if (open) {
 			renderElementControlCard();
+		}
 		ImGui::End();
 	}
 
@@ -35,8 +36,8 @@ namespace dnf_composer::user_interface
 		// Layout metrics (must be computed before the Selected elements section uses them)
 	    const float innerW    = ImGui::GetContentRegionAvail().x;
 		const float ui        = ImGui::GetIO().FontGlobalScale;
-		const float dragW     = 130.0f * ui;
-		const float panelPadX = 10.0f * ui;
+		const float dragW     = 130.0F * ui;
+		const float panelPadX = 10.0F * ui;
 		const float spacingX  = ImGui::GetStyle().ItemSpacing.x;
 
 		auto PanelHeightFor = [&](const std::shared_ptr<element::Element>& e) -> float
@@ -44,7 +45,7 @@ namespace dnf_composer::user_interface
 			const float frameH   = ImGui::GetFrameHeight();
 			const float spacingY = ImGui::GetStyle().ItemSpacing.y;
 			const float rowH     = frameH + spacingY;
-			const float panelPad = 3.0f * 8.0f * ui;
+			const float panelPad = 3.0F * 8.0F * ui;
 
 			auto h = [&](const int rows) {
 				return rows * rowH - spacingY + panelPad;
@@ -70,22 +71,23 @@ namespace dnf_composer::user_interface
 				{
 					const auto gfc = std::dynamic_pointer_cast<element::GaussFieldCoupling>(e);
 					const int numCouplings = static_cast<int>(gfc->getParameters().couplings.size());
-					return h(4 + 5 * numCouplings + dimRows);
+					return h(4 + (5 * numCouplings) + dimRows);
 				}
 				default: return h(4 + dimRows);
 			}
 		};
 
-		const float maxNaturalW = 1.0f * panelPadX + dragW + spacingX + ImGui::CalcTextSize("circular + normalized").x;
+		const float maxNaturalW = (1.0f * panelPadX) + dragW + spacingX + ImGui::CalcTextSize("circular + normalized").x;
 		const float panelW = ImMin(maxNaturalW, innerW);
 
 		// Validate a focused element still belongs to this simulation
 		if (s_focusedElement_)
 		{
 			bool stillValid = false;
-			for (const auto& e : simulation->getElements())
+			for (const auto& e : simulation->getElements()) {
 				if (e == s_focusedElement_) { stillValid = true; break; }
-			if (!stillValid) s_focusedElement_ = nullptr;
+			}
+			if (!stillValid) { s_focusedElement_ = nullptr;}
 		}
 
 		// Selected elements section - shows the most recently single-clicked node

--- a/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
@@ -361,6 +361,7 @@ namespace dnf_composer::user_interface
 			const bool hasInputPin =
 				lbl != element::ElementLabel::GAUSS_STIMULUS &&
 				lbl != element::ElementLabel::NORMAL_NOISE &&
+				lbl != element::ElementLabel::CORRELATED_NORMAL_NOISE &&
 				lbl != element::ElementLabel::BOOST_STIMULUS;
 
 			if (ImGui::BeginTable("##pins", 2, ImGuiTableFlags_None, ImVec2(minNodeSize, 0.f)))
@@ -701,6 +702,7 @@ namespace dnf_composer::user_interface
 		{
 		case element::ElementLabel::GAUSS_STIMULUS:
 		case element::ElementLabel::NORMAL_NOISE:
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE:
 		case element::ElementLabel::BOOST_STIMULUS:
 			return 0;
 		case element::ElementLabel::GAUSS_KERNEL:
@@ -812,6 +814,16 @@ namespace dnf_composer::user_interface
 			const auto nn = std::dynamic_pointer_cast<element::NormalNoise>(element);
 			if (!nn) { ImGui::TextDisabled("(type mismatch)"); break; }
 			ImGui::Text("Amplitude: %.4f", nn->getParameters().amplitude);
+			break;
+		}
+		case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+		{
+			const auto cnn = std::dynamic_pointer_cast<element::CorrelatedNormalNoise>(element);
+			if (!cnn) { ImGui::TextDisabled("(type mismatch)"); break; }
+			const auto& p = cnn->getParameters();
+			ImGui::Text("Amplitude: %.4f", p.amplitude);
+			ImGui::Text("Width: %.2f",     p.width);
+			ImGui::Text("Circular: %s",    p.circular ? "true" : "false");
 			break;
 		}
 		case element::ElementLabel::BOOST_STIMULUS:

--- a/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
@@ -311,37 +311,50 @@ namespace dnf_composer::user_interface
 	    {
 	        switch (selected)
 	        {
-	        case element::ElementLabel::NEURAL_FIELD:
-	        {
-	            static char   id[CHAR_SIZE] = "neural field u";
-	            static int    x_max         = 100;
-	            static double d_x           = 1.0;
-	            static double resting       = -10.0;
-	            static double tau           = 25.0;
-	            static double sigmoid_k     = 5.0;
+        case element::ElementLabel::NEURAL_FIELD:
+        {
+            static char   id[CHAR_SIZE] = "neural field u";
+            static int    x_max         = 100;
+            static double d_x           = 1.0;
+            static double resting       = -10.0;
+            static double tau           = 25.0;
+            static int    actFnType     = element::SIGMOID;
+            static double xShift        = 0.0;
+            static double steepness     = 5.0;
+            static double absBeta       = 100.0;
+            static const char* actFnNames[] = { "Sigmoid", "Heaviside", "AbsSigmoid" };
 
+            ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
+            ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
+            ImGui::InputInt("Size", &x_max, 0, 0);
+            ImGui::InputDouble("Step", &d_x, 0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Resting level", &resting, 0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Time scale", &tau, 0.0, 0.0, "%.2f");
+            ImGui::Combo("Activation fn.", &actFnType, actFnNames, 3);
+            ImGui::InputDouble("X shift", &xShift, 0.0, 0.0, "%.2f");
+            if (actFnType == element::SIGMOID)
+                ImGui::InputDouble("Steepness", &steepness, 0.0, 0.0, "%.2f");
+            else if (actFnType == element::ABSSIGMOID)
+                ImGui::InputDouble("Beta", &absBeta, 0.0, 0.0, "%.2f");
+            ImGui::PopItemWidth();
 
-		        	ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
-		        	ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale); // adjust width to taste
-		        	ImGui::InputInt("Size", &x_max, 0, 0);
-		        	ImGui::InputDouble("Step", &d_x, 0.0, 0.0, "%.2f");
-		        	ImGui::InputDouble("Resting level", &resting, 0.0, 0.0, "%.2f");
-		        	ImGui::InputDouble("Time scale", &tau, 0.0, 0.0, "%.2f");
-		        	ImGui::InputDouble("Sigmoid steepness", &sigmoid_k, 0.0, 0.0, "%.2f");
-		        	ImGui::PopItemWidth();
-
-	            if (addRequested)
-	            {
-	                const element::SigmoidFunction activation{ 0, sigmoid_k };
-	                const element::NeuralFieldParameters nfp{ tau, resting, activation };
-	                const element::ElementIdentifiers ids{ id };
-	                const element::ElementDimensions  dims{ x_max, d_x };
-	                const element::ElementCommonParameters common{ ids, dims };
-	                const auto nf = std::make_shared<element::NeuralField>(common, nfp);
-	                simulation->addElement(nf);
-	            }
-	            break;
-	        }
+            if (addRequested)
+            {
+                std::unique_ptr<element::ActivationFunction> af;
+                if (actFnType == element::SIGMOID)
+                    af = std::make_unique<element::SigmoidFunction>(xShift, steepness);
+                else if (actFnType == element::HEAVISIDE)
+                    af = std::make_unique<element::HeavisideFunction>(xShift);
+                else
+                    af = std::make_unique<element::AbsSigmoidFunction>(xShift, absBeta);
+                const element::NeuralFieldParameters nfp{ tau, resting, *af };
+                const element::ElementIdentifiers ids{ id };
+                const element::ElementDimensions  dims{ x_max, d_x };
+                const element::ElementCommonParameters common{ ids, dims };
+                simulation->addElement(std::make_shared<element::NeuralField>(common, nfp));
+            }
+            break;
+        }
         case element::ElementLabel::GAUSS_STIMULUS:
         {
             static char   id[CHAR_SIZE] = "gauss stimulus";
@@ -579,6 +592,32 @@ namespace dnf_composer::user_interface
                 const element::NormalNoiseParameters nnp{ amplitude };
                 const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
                 simulation->addElement(std::make_shared<element::NormalNoise>(common, nnp));
+            }
+            break;
+        }
+        case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+        {
+            static char   id[CHAR_SIZE] = "correlated normal noise";
+            static int    x_max         = 100;
+            static double d_x           = 1.0;
+            static double amplitude     = 0.05;
+            static double width         = 2.0;
+            static bool   circular      = true;
+
+            ImGui::InputTextWithHint("ID", "enter text here", id, IM_ARRAYSIZE(id));
+            ImGui::PushItemWidth(80.0f * ImGui::GetIO().FontGlobalScale);
+            ImGui::InputInt("Size",         &x_max,     0, 0);
+            ImGui::InputDouble("Step",      &d_x,       0.0, 0.0, "%.2f");
+            ImGui::InputDouble("Amplitude", &amplitude, 0.0, 0.0, "%.4f");
+            ImGui::InputDouble("Width",     &width,     0.0, 0.0, "%.2f");
+            ImGui::PopItemWidth();
+            ImGui::Checkbox("Circular", &circular);
+
+            if (addRequested)
+            {
+                const element::CorrelatedNormalNoiseParameters cnnp{ amplitude, width, circular };
+                const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, d_x } };
+                simulation->addElement(std::make_shared<element::CorrelatedNormalNoise>(common, cnnp));
             }
             break;
         }
@@ -1252,6 +1291,9 @@ namespace dnf_composer::user_interface
 			case element::ElementLabel::NORMAL_NOISE:
 				addElementNormalNoise();
 				break;
+			case element::ElementLabel::CORRELATED_NORMAL_NOISE:
+				addElementCorrelatedNormalNoise();
+				break;
 			case element::ElementLabel::GAUSS_FIELD_COUPLING:
 				addElementGaussFieldCoupling();
 				break;
@@ -1323,22 +1365,33 @@ namespace dnf_composer::user_interface
 		ImGui::InputDouble("d_x", &d_x, 0.1, 0.5, "%.2f");
 		static double tau = 25;
 		ImGui::InputDouble("tau", &tau, 1.0f, 10.0f, "%.2f");
-		static double sigmoidSteepness = 5.0f;
-		ImGui::InputDouble("sigmoid steepness", &sigmoidSteepness, 1.0f, 10.0f, "%.2f");
 		static double restingLevel = -10.0f;
 		ImGui::InputDouble("resting level", &restingLevel, 1.0f, 10.0f, "%.2f");
+		static int actFnType = element::SIGMOID;
+		static double xShift = 0.0;
+		static double steepness = 5.0;
+		static double absBeta = 100.0;
+		static const char* actFnNames[] = { "Sigmoid", "Heaviside", "AbsSigmoid" };
+		ImGui::Combo("activation fn.", &actFnType, actFnNames, 3);
+		ImGui::InputDouble("x shift", &xShift, 0.0, 0.0, "%.2f");
+		if (actFnType == element::SIGMOID)
+			ImGui::InputDouble("steepness", &steepness, 1.0f, 10.0f, "%.2f");
+		else if (actFnType == element::ABSSIGMOID)
+			ImGui::InputDouble("beta", &absBeta, 1.0f, 10.0f, "%.2f");
 
 		if (ImGui::Button("Add", { 100.0f, 30.0f }))
 		{
-			const element::SigmoidFunction activationFunction{ 0, sigmoidSteepness };
-			const element::NeuralFieldParameters nfp = { tau, restingLevel, activationFunction };
-
-			const element::ElementIdentifiers neuralFieldIdentifiers{id};
-			const element::ElementDimensions neuralFieldDimensions{ x_max, d_x };
-			const element::ElementCommonParameters commonParameters{ neuralFieldIdentifiers, neuralFieldDimensions };
-
-			const std::shared_ptr<element::NeuralField> neuralField(new element::NeuralField(commonParameters, nfp));
-			simulation->addElement(neuralField);
+			std::unique_ptr<element::ActivationFunction> af;
+			if (actFnType == element::SIGMOID)
+				af = std::make_unique<element::SigmoidFunction>(xShift, steepness);
+			else if (actFnType == element::HEAVISIDE)
+				af = std::make_unique<element::HeavisideFunction>(xShift);
+			else
+				af = std::make_unique<element::AbsSigmoidFunction>(xShift, absBeta);
+			const element::NeuralFieldParameters nfp{ tau, restingLevel, *af };
+			const element::ElementCommonParameters commonParameters{ element::ElementIdentifiers{id},
+				element::ElementDimensions{ x_max, d_x } };
+			simulation->addElement(std::make_shared<element::NeuralField>(commonParameters, nfp));
 		}
 		ImGui::PopID();
 	}
@@ -1396,6 +1449,31 @@ namespace dnf_composer::user_interface
 			simulation->addElement(gaussKernelNormalNoise);
 			simulation->createInteraction(id, "output", std::string(id) + " gauss kernel");
 			simulation->createInteraction(std::string(id) + " gauss kernel", "output", id);
+		}
+		ImGui::PopID();
+	}
+
+	void SimulationWindow::addElementCorrelatedNormalNoise() const
+	{
+		ImGui::PushID("correlated normal noise");
+		static char id[CHAR_SIZE] = "correlated normal noise a";
+		ImGui::InputTextWithHint("id", "enter text here", id, IM_ARRAYSIZE(id));
+		static int x_max = 100;
+		ImGui::InputInt("x_max", &x_max, 1.0, 10.0);
+		static double d_x = 1.0;
+		ImGui::InputDouble("d_x", &d_x, 0.1, 0.5, "%.2f");
+		static double amplitude = 0.05;
+		ImGui::InputDouble("amplitude", &amplitude, 0.01f, 1.0f, "%.4f");
+		static double width = 2.0;
+		ImGui::InputDouble("width", &width, 0.1, 1.0, "%.2f");
+		static bool circular = true;
+		ImGui::Checkbox("circular", &circular);
+
+		if (ImGui::Button("Add", { 100.0f, 30.0f }))
+		{
+			const element::CorrelatedNormalNoiseParameters cnnp{ amplitude, width, circular };
+			const element::ElementDimensions dimensions{ x_max, d_x };
+			simulation->addElement(std::make_shared<element::CorrelatedNormalNoise>(element::ElementCommonParameters{ id, dimensions }, cnnp));
 		}
 		ImGui::PopID();
 	}

--- a/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
@@ -235,7 +235,7 @@ TEST(AbsSigmoidFunction, HighBetaApproachesHeaviside)
     EXPECT_NEAR(out[1], 1.0, 1e-3);
 }
 
-TEST(AbsSigmoidFunction, AgreeswithExpSigmoidAtOriginAndAsymptotes)
+TEST(AbsSigmoidFunction, AgreesWithExpSigmoidAtOriginAndAsymptotes)
 {
     // Both sigmoid families share: output=0.5 at u=x_shift, output→0 as u→-∞, output→1 as u→+∞.
     // They differ in the transition shape (rational vs exponential), so pointwise agreement

--- a/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
@@ -235,16 +235,25 @@ TEST(AbsSigmoidFunction, HighBetaApproachesHeaviside)
     EXPECT_NEAR(out[1], 1.0, 1e-3);
 }
 
-TEST(AbsSigmoidFunction, ApproximatelySameasExpSigmoidAtHighBeta)
+TEST(AbsSigmoidFunction, AgreeswithExpSigmoidAtOriginAndAsymptotes)
 {
-    // AbsSigmoid and ExpSigmoid should agree to < 0.001 for beta >= 20
+    // Both sigmoid families share: output=0.5 at u=x_shift, output→0 as u→-∞, output→1 as u→+∞.
+    // They differ in the transition shape (rational vs exponential), so pointwise agreement
+    // is only expected at u=x_shift and at large |u|.
     AbsSigmoidFunction absSig{ 0.0, 50.0 };
     SigmoidFunction expSig{ 0.0, 50.0 };
-    const std::vector<double> input{ -2.0, -0.5, 0.0, 0.5, 2.0 };
-    const auto absOut = absSig(input);
-    const auto expOut = expSig(input);
-    for (size_t i = 0; i < input.size(); ++i)
-        EXPECT_NEAR(absOut[i], expOut[i], 0.001);
+    const std::vector<double> atOrigin{ 0.0 };
+    const auto absAtOrigin = absSig(atOrigin);
+    const auto expAtOrigin = expSig(atOrigin);
+    EXPECT_NEAR(absAtOrigin[0], expAtOrigin[0], 1e-6);  // both = 0.5 at u=0
+
+    const std::vector<double> atSaturation{ -100.0, 100.0 };
+    const auto absAtSat = absSig(atSaturation);
+    const auto expAtSat = expSig(atSaturation);
+    EXPECT_NEAR(absAtSat[0], 0.0, 1e-3);
+    EXPECT_NEAR(absAtSat[1], 1.0, 1e-3);
+    EXPECT_NEAR(expAtSat[0], 0.0, 1e-3);
+    EXPECT_NEAR(expAtSat[1], 1.0, 1e-3);
 }
 
 TEST(AbsSigmoidFunction, OutputSizeMatchesInputSize)

--- a/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
@@ -168,3 +168,120 @@ TEST(HeavisideFunction, ToStringIsNonEmpty)
     HeavisideFunction h{ 0.0 };
     EXPECT_FALSE(h.toString().empty());
 }
+
+// ---------------------------------------------------------------------------
+// AbsSigmoidFunction
+// ---------------------------------------------------------------------------
+
+TEST(AbsSigmoidFunction, ConstructionStoresParameters)
+{
+    const AbsSigmoidFunction a{ 2.0, 50.0 };
+    EXPECT_DOUBLE_EQ(a.getXShift(), 2.0);
+    EXPECT_DOUBLE_EQ(a.getBeta(), 50.0);
+}
+
+TEST(AbsSigmoidFunction, OutputAtShiftIsHalf)
+{
+    // sigma(x_shift) = 0.5*(1 + beta*0/(1+beta*0)) = 0.5
+    AbsSigmoidFunction a{ 3.0, 100.0 };
+    const std::vector<double> input{ 3.0 };
+    const auto out = a(input);
+    EXPECT_NEAR(out[0], 0.5, 1e-12);
+}
+
+TEST(AbsSigmoidFunction, OutputInUnitInterval)
+{
+    AbsSigmoidFunction a{ 0.0, 20.0 };
+    const std::vector<double> input{ -100.0, -1.0, 0.0, 1.0, 100.0 };
+    for (const auto out = a(input); double v : out)
+    {
+        EXPECT_GE(v, 0.0);
+        EXPECT_LE(v, 1.0);
+    }
+}
+
+TEST(AbsSigmoidFunction, MonotonicallyIncreasing)
+{
+    AbsSigmoidFunction a{ 0.0, 10.0 };
+    const std::vector<double> input{ -5.0, -1.0, 0.0, 1.0, 5.0 };
+    const auto out = a(input);
+    for (size_t i = 1; i < out.size(); ++i)
+        EXPECT_GT(out[i], out[i - 1]);
+}
+
+TEST(AbsSigmoidFunction, LargePositiveInputApproachesOne)
+{
+    AbsSigmoidFunction a{ 0.0, 100.0 };
+    const std::vector<double> input{ 1000.0 };
+    const auto out = a(input);
+    EXPECT_NEAR(out[0], 1.0, 1e-3);
+}
+
+TEST(AbsSigmoidFunction, LargeNegativeInputApproachesZero)
+{
+    AbsSigmoidFunction a{ 0.0, 100.0 };
+    const std::vector<double> input{ -1000.0 };
+    const auto out = a(input);
+    EXPECT_NEAR(out[0], 0.0, 1e-3);
+}
+
+TEST(AbsSigmoidFunction, HighBetaApproachesHeaviside)
+{
+    // At beta=1e6 the rational sigmoid should be indistinguishable from a step
+    AbsSigmoidFunction a{ 0.0, 1e6 };
+    const std::vector<double> input{ -0.01, 0.01 };
+    const auto out = a(input);
+    EXPECT_NEAR(out[0], 0.0, 1e-3);
+    EXPECT_NEAR(out[1], 1.0, 1e-3);
+}
+
+TEST(AbsSigmoidFunction, ApproximatelySameasExpSigmoidAtHighBeta)
+{
+    // AbsSigmoid and ExpSigmoid should agree to < 0.001 for beta >= 20
+    AbsSigmoidFunction absSig{ 0.0, 50.0 };
+    SigmoidFunction expSig{ 0.0, 50.0 };
+    const std::vector<double> input{ -2.0, -0.5, 0.0, 0.5, 2.0 };
+    const auto absOut = absSig(input);
+    const auto expOut = expSig(input);
+    for (size_t i = 0; i < input.size(); ++i)
+        EXPECT_NEAR(absOut[i], expOut[i], 0.001);
+}
+
+TEST(AbsSigmoidFunction, OutputSizeMatchesInputSize)
+{
+    AbsSigmoidFunction a{ 0.0, 10.0 };
+    const std::vector<double> input(60, 0.5);
+    const auto out = a(input);
+    EXPECT_EQ(out.size(), input.size());
+}
+
+TEST(AbsSigmoidFunction, EqualityOperatorSameParameters)
+{
+    const AbsSigmoidFunction a{ 1.0, 50.0 };
+    const AbsSigmoidFunction b{ 1.0, 50.0 };
+    EXPECT_TRUE(a == b);
+}
+
+TEST(AbsSigmoidFunction, EqualityOperatorDifferentParameters)
+{
+    const AbsSigmoidFunction a{ 1.0, 50.0 };
+    const AbsSigmoidFunction b{ 2.0, 50.0 };
+    EXPECT_FALSE(a == b);
+}
+
+TEST(AbsSigmoidFunction, CloneProducesSameOutput)
+{
+    AbsSigmoidFunction a{ 1.5, 30.0 };
+    const auto clone = a.clone();
+    const std::vector<double> input{ -2.0, 0.0, 1.5, 5.0 };
+    const auto cloneOut = (*clone)(input);
+    const auto directOut = a(input);
+    for (size_t i = 0; i < input.size(); ++i)
+        EXPECT_DOUBLE_EQ(cloneOut[i], directOut[i]);
+}
+
+TEST(AbsSigmoidFunction, ToStringIsNonEmpty)
+{
+    const AbsSigmoidFunction a{ 0.0, 100.0 };
+    EXPECT_FALSE(a.toString().empty());
+}

--- a/dynamic-neural-field-composer/tests/elements/test_correlated_normal_noise.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_correlated_normal_noise.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <numeric>
+#include <cmath>
+
+#include "elements/correlated_normal_noise.h"
+#include "elements/normal_noise.h"
+
+using namespace dnf_composer;
+using namespace dnf_composer::element;
+
+static std::shared_ptr<CorrelatedNormalNoise> makeCNN(const std::string& name,
+                                                       double amplitude = 0.05,
+                                                       double width = 2.0,
+                                                       bool circular = true,
+                                                       int size = 100)
+{
+    ElementCommonParameters cp{ name, size };
+    CorrelatedNormalNoiseParameters p{ amplitude, width, circular };
+    return std::make_shared<CorrelatedNormalNoise>(cp, p);
+}
+
+TEST(CorrelatedNormalNoise, LabelIsCorrect)
+{
+    const auto n = makeCNN("cnn");
+    EXPECT_EQ(n->getLabel(), ElementLabel::CORRELATED_NORMAL_NOISE);
+}
+
+TEST(CorrelatedNormalNoise, OutputSizeMatchesFieldSize)
+{
+    const auto n = makeCNN("cnn", 0.05, 2.0, true, 80);
+    n->init();
+    n->step(0.0, 1.0);
+    EXPECT_EQ(n->getComponent("output").size(), 80u);
+}
+
+TEST(CorrelatedNormalNoise, OutputIsNonZeroAfterStep)
+{
+    const auto n = makeCNN("cnn", 1.0, 2.0);
+    n->init();
+    n->step(0.0, 1.0);
+    const auto& out = n->getComponent("output");
+    const double sum = std::accumulate(out.begin(), out.end(), 0.0,
+                                       [](double a, double b) { return a + std::abs(b); });
+    EXPECT_GT(sum, 0.0);
+}
+
+TEST(CorrelatedNormalNoise, ScalesWithAmplitude)
+{
+    // Output standard deviation should scale linearly with amplitude.
+    // Run many steps and compare variance between two amplitude settings.
+    constexpr int steps = 500;
+    constexpr int sz = 100;
+    constexpr double dt = 1.0;
+
+    auto low  = makeCNN("low",  0.1, 1.0, false, sz);
+    auto high = makeCNN("high", 1.0, 1.0, false, sz);
+    low->init();  high->init();
+
+    double varLow = 0.0, varHigh = 0.0;
+    for (int s = 0; s < steps; ++s)
+    {
+        low->step(0.0, dt);  high->step(0.0, dt);
+        for (const double v : low->getComponent("output"))  varLow  += v * v;
+        for (const double v : high->getComponent("output")) varHigh += v * v;
+    }
+    // High amplitude should have roughly 100x more variance (amplitude ratio 10x → variance 100x)
+    EXPECT_GT(varHigh / varLow, 50.0);
+}
+
+TEST(CorrelatedNormalNoise, SpatialCorrelationPresent)
+{
+    // For large width, adjacent samples should be positively correlated.
+    // For width=0.01 (essentially uncorrelated) the lag-1 autocorrelation is near 0.
+    constexpr int steps = 2000;
+    constexpr int sz = 100;
+    constexpr double dt = 1.0;
+
+    auto corr = makeCNN("corr", 1.0, 10.0, false, sz);
+    corr->init();
+
+    double ac_corr = 0.0;
+    for (int s = 0; s < steps; ++s)
+    {
+        corr->step(0.0, dt);
+        const auto& out = corr->getComponent("output");
+        for (int i = 0; i < sz - 1; ++i)
+            ac_corr += out[i] * out[i + 1];
+    }
+    // With width=10, adjacent elements should be strongly positively correlated
+    EXPECT_GT(ac_corr / steps, 0.0);
+}
+
+TEST(CorrelatedNormalNoise, GetSetParameters)
+{
+    const auto n = makeCNN("cnn");
+    CorrelatedNormalNoiseParameters p{ 0.1, 3.0, false };
+    n->setParameters(p);
+    const auto got = n->getParameters();
+    EXPECT_NEAR(got.amplitude, 0.1, 1e-9);
+    EXPECT_NEAR(got.width, 3.0, 1e-9);
+    EXPECT_FALSE(got.circular);
+}
+
+TEST(CorrelatedNormalNoise, ToStringIsNonEmpty)
+{
+    const auto n = makeCNN("cnn");
+    EXPECT_FALSE(n->toString().empty());
+}
+
+TEST(CorrelatedNormalNoise, HigherAutocorrelationThanWhiteNoise)
+{
+    // CorrelatedNormalNoise with large width should have much higher lag-1
+    // spatial autocorrelation than plain NormalNoise.
+    constexpr int steps = 1000;
+    constexpr int sz    = 100;
+    constexpr double dt = 1.0;
+
+    auto cnn = makeCNN("cnn", 1.0, 10.0, false, sz);
+    cnn->init();
+
+    ElementCommonParameters nnCp{ "nn", sz };
+    NormalNoiseParameters   nnP{ 1.0 };
+    auto nn = std::make_shared<NormalNoise>(nnCp, nnP);
+    nn->init();
+
+    double acCorr = 0.0, acWhite = 0.0;
+    for (int s = 0; s < steps; ++s)
+    {
+        cnn->step(0.0, dt);
+        nn->step(0.0, dt);
+        const auto& outC = cnn->getComponent("output");
+        const auto& outW = nn->getComponent("output");
+        for (int i = 0; i < sz - 1; ++i)
+        {
+            acCorr += outC[i] * outC[i + 1];
+            acWhite += outW[i] * outW[i + 1];
+        }
+    }
+    // Spatially correlated noise must have substantially higher autocorrelation
+    EXPECT_GT(acCorr / steps, acWhite / steps + 1.0);
+}
+
+TEST(CorrelatedNormalNoise, CircularAndNonCircularSameSizeOutput)
+{
+    const auto circ    = makeCNN("circ",    0.05, 2.0, true,  80);
+    const auto nonCirc = makeCNN("noncirc", 0.05, 2.0, false, 80);
+    circ->init();
+    nonCirc->init();
+    circ->step(0.0, 1.0);
+    nonCirc->step(0.0, 1.0);
+    EXPECT_EQ(circ->getComponent("output").size(), 80u);
+    EXPECT_EQ(nonCirc->getComponent("output").size(), 80u);
+}

--- a/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
@@ -238,3 +238,68 @@ TEST(NeuralFieldBumps, NoBumpsAtRestingLevel)
     f->step(1.0, 1.0);
     EXPECT_TRUE(f->getBumps().empty());
 }
+
+// ---------------------------------------------------------------------------
+// AbsSigmoidFunction as activation function
+// ---------------------------------------------------------------------------
+
+TEST(NeuralFieldAbsSigmoid, ConstructionAndStepDoNotThrow)
+{
+    const AbsSigmoidFunction sig{ 0.0, 100.0 };
+    const NeuralFieldParameters nfp{ 25.0, -5.0, sig };
+    const ElementCommonParameters cp{ std::string("f"), 100 };
+    const auto f = std::make_shared<NeuralField>(cp, nfp);
+    EXPECT_NO_THROW(f->init());
+    EXPECT_NO_THROW(f->step(0.0, 1.0));
+}
+
+TEST(NeuralFieldAbsSigmoid, OutputNearZeroAtRestingLevel)
+{
+    // AbsSigmoid(0, beta=100): at x=-5 output ≈ 0 (deeply sub-threshold)
+    const AbsSigmoidFunction sig{ 0.0, 100.0 };
+    const NeuralFieldParameters nfp{ 25.0, -5.0, sig };
+    const ElementCommonParameters cp{ std::string("f"), 100 };
+    const auto f = std::make_shared<NeuralField>(cp, nfp);
+    f->init();
+    f->step(0.0, 1.0);
+    for (const auto out = f->getComponent("output"); const double v : out)
+        EXPECT_LT(v, 0.1);
+}
+
+TEST(NeuralFieldAbsSigmoid, RisesWithStrongStimulus)
+{
+    Simulation sim("abs-sigmoid-test", 1.0, 0.0, 0.0);
+
+    const AbsSigmoidFunction sig{ 0.0, 100.0 };
+    const NeuralFieldParameters nfp{ 25.0, -5.0, sig };
+    const ElementCommonParameters cp{ std::string("field"), 100 };
+    const auto field = std::make_shared<NeuralField>(cp, nfp);
+
+    const auto stim = makeStimulus("stim", 50.0, 30.0);
+    sim.addElement(stim);
+    sim.addElement(field);
+    sim.createInteraction("stim", "output", "field");
+    sim.init();
+
+    const double initMax = field->getHighestActivation();
+    for (int i = 0; i < 50; ++i)
+        sim.step();
+
+    EXPECT_GT(field->getHighestActivation(), initMax);
+}
+
+TEST(NeuralFieldAbsSigmoid, GetSetParametersRoundtrip)
+{
+    const AbsSigmoidFunction sig{ 0.5, 50.0 };
+    const NeuralFieldParameters nfp{ 20.0, -3.0, sig };
+    const ElementCommonParameters cp{ std::string("f"), 50 };
+    NeuralField f(cp, nfp);
+    const auto got = f.getParameters();
+    EXPECT_DOUBLE_EQ(got.tau, 20.0);
+    EXPECT_DOUBLE_EQ(got.startingRestingLevel, -3.0);
+    // Verify the stored function is AbsSigmoidFunction
+    const auto* stored = dynamic_cast<const AbsSigmoidFunction*>(got.activationFunction.get());
+    ASSERT_NE(stored, nullptr);
+    EXPECT_NEAR(stored->getXShift(), 0.5, 1e-9);
+    EXPECT_NEAR(stored->getBeta(),   50.0, 1e-9);
+}


### PR DESCRIPTION
## What and why

Adds `CorrelatedNormalNoise` as a new element type and extends the
activation function system with `AbsSigmoidFunction` (cedar's default
sigmoid). Both additions are needed for cross-framework parity with
Cosivina and Cedar.

**CorrelatedNormalNoise** generates spatially correlated Gaussian noise
via convolution of white noise with a Gaussian kernel (parameters:
`amplitude`, `width`, `circular`). This matches Cosivina's
`NormalNoise` with spatial correlation and complements the existing
uncorrelated `NormalNoise` element.

**AbsSigmoidFunction** implements the rational sigmoid
`σ(u) = 0.5·(1 + β·u / (1 + β·|u|))`, which is Cedar's default
activation function. Adding it allows dnfc simulations to match Cedar's
dynamics exactly (same fixed-point behaviour), which is a prerequisite
for the ongoing cross-framework numerical validation.

**Activation function Doxygen** was updated with cross-framework
equivalence tables for all three activation functions (Sigmoid,
AbsSigmoid, Heaviside), mapping dnfc parameter names to cedar and
cosivina equivalents.

**UI** was extended to allow configuring and adding `CorrelatedNormalNoise`
elements from the simulation window, and the neural field configuration
panel now exposes the activation function type selector (Sigmoid /
AbsSigmoid / Heaviside).

## How to verify

1. Build and run: the simulation window should show a
   *Correlated Normal Noise* option in the element-add panel.
2. Add a `CorrelatedNormalNoise` element; connect it to a neural field;
   confirm spatially smooth noise appears in the activation plot.
3. Create a neural field with `AbsSigmoid` activation; at resting level
   `h = -8`, confirm the field settles to ≈ −7.995 (not −8.000), matching
   Cedar's known fixed-point offset.
4. Run the test suite — `test_correlated_normal_noise` and
   `test_activation_function` must pass.

## Checklist

- [x] Tests added or updated
- [x] Doxygen updated (activation_function.h — cross-framework tables)
- [ ] Wiki updated (if user-visible behaviour changed)
- [x] CI passes (Windows, Linux, macOS)
