### PR TITLE
Add Resize and Resize2D elements for spatial resampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Removed
+- Deprecated cross-dimension kernel capability: the optional `outputFieldDimensions`
+  parameter on `GaussKernel`, `MexicanHatKernel`, `OscillatoryKernel`, and
+  `AsymmetricGaussKernel` (and the associated **Output Size** / **Output Step** UI
+  controls) has been removed. Use the standalone `Resize` / `Resize2D` elements to
+  resample between neural fields of different spatial sizes.
+
 ## [2.7.1] - 2026-06-01
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ More ready-to-run examples are in the [`examples/`](dynamic-neural-field-compose
 | Noise | `NormalNoise`, `CorrelatedNormalNoise` (+ 2D variants) |
 | Couplings | `FieldCoupling`, `GaussFieldCoupling` |
 | Memory | `MemoryTrace`, `MemoryTrace2d` |
+| Resampling | `Resize`, `Resize2d` — interpolate an input field to a different spatial size (linear / nearest / cubic) |
 
 
 ![Element suite — neural fields, kernels, stimuli, couplings in 1D and 2D](./dynamic-neural-field-composer/resources/images/headline-elements.jpg)

--- a/dynamic-neural-field-composer/CMakeLists.txt
+++ b/dynamic-neural-field-composer/CMakeLists.txt
@@ -190,6 +190,8 @@ set(src
         "src/elements/correlated_normal_noise_2d.cpp"
         "src/elements/asymmetric_gauss_kernel_2d.cpp"
         "src/elements/memory_trace_2d.cpp"
+        "src/elements/resize.cpp"
+        "src/elements/resize_2d.cpp"
 
         "src/element_parameters/element_parameters.cpp"
 

--- a/dynamic-neural-field-composer/examples/CMakeLists.txt
+++ b/dynamic-neural-field-composer/examples/CMakeLists.txt
@@ -26,6 +26,7 @@ add_example_executable(example_multi_peak_2d            multi_peak_2d.cpp)
 add_example_executable(example_weighted_field_coupling  weighted_field_coupling.cpp)
 add_example_executable(example_gaussian_field_coupling  gaussian_field_coupling.cpp)
 add_example_executable(example_hebbian_learning         hebbian_learning.cpp)
+add_example_executable(example_resize                    resize.cpp)
 #add_example_executable(example_oja_learning             oja_learning.cpp)
 #add_example_executable(example_delta_rule_learning      delta_rule_learning.cpp)
 

--- a/dynamic-neural-field-composer/examples/resize.cpp
+++ b/dynamic-neural-field-composer/examples/resize.cpp
@@ -1,0 +1,137 @@
+#include "visualization/visualization.h"
+#include "application/application.h"
+#include "user_interface/static_layout.h"
+#include "user_interface/main_menu_bar.h"
+
+int main()
+{
+	try
+	{
+		using namespace dnf_composer;
+
+		const auto simulation = std::make_shared<Simulation>("Resize (example)",
+			5.0, 0.0, 0.0);
+		const auto visualization = std::make_shared<Visualization>(simulation);
+		const Application app{ simulation, visualization };
+
+		app.addWindow<user_interface::MainMenuBar>();
+		app.addWindow<user_interface::StaticLayoutWindow>(simulation, visualization);
+
+		// ──────────────────────────────────────────────────────────────────
+		// 1D architecture: stimulus a -> field u -> kernel u-u
+		//                  field u -> resize u-v -> field v
+		// Field v has a different spatial size and discretization than field u.
+		// ──────────────────────────────────────────────────────────────────
+		const element::ElementDimensions dimU1D(100, 1.0); // size 100, step 1.0
+		const element::ElementDimensions dimV1D(50, 2.0);  // size 25,  step 2.0
+
+		const auto sA = std::make_shared<element::GaussStimulus>(
+			element::ElementCommonParameters{ "stimulus a (1d)", dimU1D },
+			element::GaussStimulusParameters{ 5.0, 10.0, 50.0 });
+
+		const auto u = std::make_shared<element::NeuralField>(
+			element::ElementCommonParameters{ "neural field u (1d)", dimU1D },
+			element::NeuralFieldParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		const auto kUU = std::make_shared<element::GaussKernel>(
+			element::ElementCommonParameters{ "kernel u-u (1d)", dimU1D },
+			element::GaussKernelParameters{ 3.0, 4.0, -0.01, true, true });
+
+		const auto resizeUV = std::make_shared<element::Resize>(
+			element::ElementCommonParameters{ "resize u-v (1d)", dimV1D },
+			element::ResizeParameters{ element::InterpolationMethod::LINEAR, dimU1D });
+
+		const auto v = std::make_shared<element::NeuralField>(
+			element::ElementCommonParameters{ "neural field v (1d)", dimV1D },
+			element::NeuralFieldParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		simulation->addElement(sA);
+		simulation->addElement(u);
+		simulation->addElement(kUU);
+		simulation->addElement(resizeUV);
+		simulation->addElement(v);
+
+		u->addInput(sA);
+		u->addInput(kUU);
+		kUU->addInput(u);
+		resizeUV->addInput(u);
+		v->addInput(resizeUV);
+
+		visualization->plot({ {u->getUniqueName(), "activation"} });
+		visualization->plot({ {v->getUniqueName(), "activation"} });
+
+		// ──────────────────────────────────────────────────────────────────
+		// 2D architecture: stimulus a -> field u -> kernel u-u
+		//                  field u -> resize u-v -> field v
+		// Field v has a different spatial size than field u.
+		// ──────────────────────────────────────────────────────────────────
+		const element::ElementDimensions dimU2D(50, 50, 1.0, 1.0); // 50 x 50
+		const element::ElementDimensions dimV2D(80, 80, 1.0, 1.0); // 80 x 80
+
+		const auto sA2 = std::make_shared<element::GaussStimulus2D>(
+			element::ElementCommonParameters{ "stimulus a (2d)", dimU2D },
+			element::GaussStimulus2DParameters{ 3.0, 10.0, 25.0, 25.0 });
+
+		const auto u2 = std::make_shared<element::NeuralField2D>(
+			element::ElementCommonParameters{ "neural field u (2d)", dimU2D },
+			element::NeuralField2DParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		const auto kUU2 = std::make_shared<element::GaussKernel2D>(
+			element::ElementCommonParameters{ "kernel u-u (2d)", dimU2D },
+			element::GaussKernel2DParameters{ 3.0, 4.0, -0.01, true, true });
+
+		const auto resizeUV2 = std::make_shared<element::Resize2D>(
+			element::ElementCommonParameters{ "resize u-v (2d)", dimV2D },
+			element::Resize2DParameters{ element::InterpolationMethod::LINEAR, dimU2D });
+
+		const auto v2 = std::make_shared<element::NeuralField2D>(
+			element::ElementCommonParameters{ "neural field v (2d)", dimV2D },
+			element::NeuralField2DParameters{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } });
+
+		simulation->addElement(sA2);
+		simulation->addElement(u2);
+		simulation->addElement(kUU2);
+		simulation->addElement(resizeUV2);
+		simulation->addElement(v2);
+
+		u2->addInput(sA2);
+		u2->addInput(kUU2);
+		kUU2->addInput(u2);
+		resizeUV2->addInput(u2);
+		v2->addInput(resizeUV2);
+
+		visualization->plot(PlotCommonParameters{ PlotType::HEATMAP,
+			PlotAnnotations{ "Neural field u activation (2d)", "Spatial dimension (x)", "Spatial dimension (y)" } },
+			HeatmapParameters{},
+			{ {u2->getUniqueName(), "activation"} });
+		visualization->plot(PlotCommonParameters{ PlotType::HEATMAP,
+			PlotAnnotations{ "Neural field v activation (2d)", "Spatial dimension (x)", "Spatial dimension (y)" } },
+			HeatmapParameters{},
+			{ {v2->getUniqueName(), "activation"} });
+
+		app.init();
+
+		while (!app.hasGUIBeenClosed())
+		{
+			app.step();
+		}
+
+		app.close();
+	}
+	catch (const dnf_composer::Exception& ex)
+	{
+		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return static_cast<int>(ex.getErrorCode());
+	}
+	catch (const std::exception& ex)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+	catch (...)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Unknown exception occurred. ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+}

--- a/dynamic-neural-field-composer/include/element_parameters/element_parameters.h
+++ b/dynamic-neural-field-composer/include/element_parameters/element_parameters.h
@@ -36,6 +36,9 @@ namespace dnf_composer::element
 		CORRELATED_NORMAL_NOISE_2D,
 		ASYMMETRIC_GAUSS_KERNEL_2D,
 		MEMORY_TRACE_2D,
+
+		RESIZE,
+		RESIZE_2D,
 	};
 
 	inline const std::map<ElementLabel, std::string> ElementLabelToString = {
@@ -65,6 +68,9 @@ namespace dnf_composer::element
 		{CORRELATED_NORMAL_NOISE_2D, "correlated normal noise 2d" },
 		{ASYMMETRIC_GAUSS_KERNEL_2D, "asymmetric gauss kernel 2d" },
 		{MEMORY_TRACE_2D, "memory trace 2d" },
+
+		{RESIZE, "resize" },
+		{RESIZE_2D, "resize 2d" },
 	};
 
 	struct ElementDimensions

--- a/dynamic-neural-field-composer/include/elements/element_factory.h
+++ b/dynamic-neural-field-composer/include/elements/element_factory.h
@@ -26,6 +26,8 @@
 #include "elements/correlated_normal_noise_2d.h"
 #include "elements/asymmetric_gauss_kernel_2d.h"
 #include "elements/memory_trace_2d.h"
+#include "elements/resize.h"
+#include "elements/resize_2d.h"
 
 namespace dnf_composer::element
 {

--- a/dynamic-neural-field-composer/include/elements/oscillatory_kernel_2d.h
+++ b/dynamic-neural-field-composer/include/elements/oscillatory_kernel_2d.h
@@ -22,8 +22,7 @@ namespace dnf_composer::element
 	/**
 	 * @brief Parameters for OscillatoryKernel2D.
 	 *
-	 * Mirrors OscillatoryKernelParameters but without outputFieldDimensions,
-	 * since this kernel always operates on a 2D field.
+	 * Mirrors OscillatoryKernelParameters.
 	 * zeroCrossings are clamped to [0, 1]; decay must be positive.
 	 */
 	struct OscillatoryKernel2DParameters final : ElementSpecificParameters

--- a/dynamic-neural-field-composer/include/elements/resize.h
+++ b/dynamic-neural-field-composer/include/elements/resize.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <iomanip>
+
+#include "tools/math.h"
+#include "element.h"
+
+namespace dnf_composer::element
+{
+	/// @brief Interpolation method used when resampling an input field to a new size.
+	/// @ingroup elements
+	enum class InterpolationMethod : int
+	{
+		LINEAR,  ///< Piecewise linear interpolation.
+		NEAREST, ///< Nearest-neighbour sampling.
+		CUBIC    ///< Catmull-Rom cubic spline interpolation.
+	};
+
+	/// @brief Maps InterpolationMethod values to human-readable strings.
+	inline const std::map<InterpolationMethod, std::string> InterpolationMethodToString = {
+		{InterpolationMethod::LINEAR, "linear"},
+		{InterpolationMethod::NEAREST, "nearest"},
+		{InterpolationMethod::CUBIC, "cubic"}
+	};
+
+	/// @brief Parameters for a 1D Resize element.
+	/// @ingroup elements
+	struct ResizeParameters final : ElementSpecificParameters
+	{
+		InterpolationMethod method;        ///< Interpolation method used for resampling.
+		ElementDimensions inputDimensions; ///< Spatial dimensions of the source (input) field.
+
+		/// @brief Construct Resize parameters.
+		/// @param method            Interpolation method (default LINEAR).
+		/// @param inputDimensions   Dimensions of the source field (drives the input buffer size).
+		explicit ResizeParameters(const InterpolationMethod method = InterpolationMethod::LINEAR,
+			const ElementDimensions& inputDimensions = ElementDimensions{})
+			: method(method), inputDimensions(inputDimensions)
+		{}
+
+		bool operator==(const ResizeParameters& other) const
+		{
+			constexpr double epsilon = 1e-6;
+			return method == other.method &&
+				inputDimensions.size == other.inputDimensions.size &&
+				std::abs(inputDimensions.d_x - other.inputDimensions.d_x) < epsilon;
+		}
+
+		[[nodiscard]] std::string toString() const override
+		{
+			std::ostringstream result;
+			result << "Parameters: ["
+				<< "Interpolation method: " << InterpolationMethodToString.at(method) << ", "
+				<< "Input field dimensions: " << inputDimensions.toString()
+				<< "]";
+			return result.str();
+		}
+	};
+
+	/// @brief Resamples a 1D input field of size N to this element's output size M.
+	///
+	/// On each @c step(), Resize reads its input field's "output" component (size N)
+	/// and resamples it to its own output size M using the configured
+	/// @c InterpolationMethod (linear, nearest, or cubic). The output size is the
+	/// element's own declared dimension; the input size is taken from the connected
+	/// source. Because the input and output sizes differ, Resize overrides
+	/// @c addInput() to size the "input" component to the source's size.
+	///
+	/// @ingroup elements
+	class Resize final : public Element
+	{
+	private:
+		ResizeParameters parameters;
+	public:
+		/// @brief Construct a Resize element.
+		/// @param elementCommonParameters  Name, label, and output dimensions (size M).
+		/// @param parameters               Resize-specific parameters (method, input dimensions).
+		Resize(const ElementCommonParameters& elementCommonParameters,
+			const ResizeParameters& parameters);
+
+		void init() override;
+		void step(double t, double deltaT) override;
+		void addInput(const std::shared_ptr<Element>& inputElement,
+			const std::string& inputComponent = "output") override;
+		std::string toString() const override;
+		std::shared_ptr<Element> clone() const override;
+
+		/// @brief Resize the input field dimensions and rebuild the input buffer.
+		/// Connections are not removed automatically — call removeInputs()/removeOutputs()
+		/// first if needed (the UI does this before calling).
+		void changeInputDimensions(const ElementDimensions& newInputDimensions);
+
+		void setParameters(const ResizeParameters& parameters);
+		[[nodiscard]] ResizeParameters getParameters() const;
+	};
+}

--- a/dynamic-neural-field-composer/include/elements/resize.h
+++ b/dynamic-neural-field-composer/include/elements/resize.h
@@ -43,10 +43,8 @@ namespace dnf_composer::element
 
 		bool operator==(const ResizeParameters& other) const
 		{
-			constexpr double epsilon = 1e-6;
 			return method == other.method &&
-				inputDimensions.size == other.inputDimensions.size &&
-				std::abs(inputDimensions.d_x - other.inputDimensions.d_x) < epsilon;
+				inputDimensions == other.inputDimensions;
 		}
 
 		[[nodiscard]] std::string toString() const override

--- a/dynamic-neural-field-composer/include/elements/resize_2d.h
+++ b/dynamic-neural-field-composer/include/elements/resize_2d.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <cmath>
+#include <sstream>
+#include <iomanip>
+
+#include "tools/math.h"
+#include "element.h"
+#include "resize.h" // for InterpolationMethod and InterpolationMethodToString
+
+namespace dnf_composer::element
+{
+	/// @brief Parameters for a 2D Resize element.
+	/// @ingroup elements
+	struct Resize2DParameters final : ElementSpecificParameters
+	{
+		InterpolationMethod method;        ///< Interpolation method used for resampling.
+		ElementDimensions inputDimensions; ///< Spatial dimensions of the source (input) field.
+
+		/// @brief Construct Resize2D parameters.
+		/// @param method            Interpolation method (default LINEAR).
+		/// @param inputDimensions   Dimensions of the source field (drives the input buffer size).
+		explicit Resize2DParameters(const InterpolationMethod method = InterpolationMethod::LINEAR,
+			const ElementDimensions& inputDimensions = ElementDimensions{ 100, 100, 1.0, 1.0 })
+			: method(method), inputDimensions(inputDimensions)
+		{}
+
+		bool operator==(const Resize2DParameters& other) const
+		{
+			constexpr double epsilon = 1e-6;
+			return method == other.method &&
+				inputDimensions.size_x == other.inputDimensions.size_x &&
+				inputDimensions.size_y == other.inputDimensions.size_y &&
+				std::abs(inputDimensions.d_x - other.inputDimensions.d_x) < epsilon &&
+				std::abs(inputDimensions.d_y - other.inputDimensions.d_y) < epsilon;
+		}
+
+		[[nodiscard]] std::string toString() const override
+		{
+			std::ostringstream result;
+			result << "Parameters: ["
+				<< "Interpolation method: " << InterpolationMethodToString.at(method) << ", "
+				<< "Input field dimensions: " << inputDimensions.toString()
+				<< "]";
+			return result.str();
+		}
+	};
+
+	/// @brief Resamples a 2D input field of size (Nx x Ny) to this element's output size (Mx x My).
+	///
+	/// On each @c step(), Resize2D reads its input field's "output" component
+	/// (a y-major flattened Nx x Ny matrix) and resamples it to its own output size
+	/// (Mx x My) using the configured @c InterpolationMethod. Resampling is performed
+	/// separably: each row is resampled along x, then each column along y, reusing the
+	/// 1D resampling helpers in tools::math. As with Resize, the input and output
+	/// sizes differ, so @c addInput() is overridden to size the "input" component to the
+	/// source's size.
+	///
+	/// @ingroup elements
+	class Resize2D final : public Element
+	{
+	private:
+		Resize2DParameters parameters;
+		std::vector<double> scratch; ///< Intermediate buffer (Mx x Ny) for the separable pass.
+	public:
+		/// @brief Construct a Resize2D element.
+		/// @param elementCommonParameters  Name, label, and output dimensions (Mx x My).
+		/// @param parameters               Resize-specific parameters (method, input dimensions).
+		Resize2D(const ElementCommonParameters& elementCommonParameters,
+			const Resize2DParameters& parameters);
+
+		void init() override;
+		void step(double t, double deltaT) override;
+		void addInput(const std::shared_ptr<Element>& inputElement,
+			const std::string& inputComponent = "output") override;
+		std::string toString() const override;
+		std::shared_ptr<Element> clone() const override;
+
+		/// @brief Resize the input field dimensions and rebuild the input buffer.
+		/// Connections are not removed automatically — call removeInputs()/removeOutputs()
+		/// first if needed (the UI does this before calling).
+		void changeInputDimensions(const ElementDimensions& newInputDimensions);
+
+		void setParameters(const Resize2DParameters& parameters);
+		[[nodiscard]] Resize2DParameters getParameters() const;
+	};
+}

--- a/dynamic-neural-field-composer/include/elements/resize_2d.h
+++ b/dynamic-neural-field-composer/include/elements/resize_2d.h
@@ -27,12 +27,8 @@ namespace dnf_composer::element
 
 		bool operator==(const Resize2DParameters& other) const
 		{
-			constexpr double epsilon = 1e-6;
 			return method == other.method &&
-				inputDimensions.size_x == other.inputDimensions.size_x &&
-				inputDimensions.size_y == other.inputDimensions.size_y &&
-				std::abs(inputDimensions.d_x - other.inputDimensions.d_x) < epsilon &&
-				std::abs(inputDimensions.d_y - other.inputDimensions.d_y) < epsilon;
+				inputDimensions == other.inputDimensions;
 		}
 
 		[[nodiscard]] std::string toString() const override
@@ -61,7 +57,11 @@ namespace dnf_composer::element
 	{
 	private:
 		Resize2DParameters parameters;
-		std::vector<double> scratch; ///< Intermediate buffer (Mx x Ny) for the separable pass.
+		std::vector<double> scratch;  ///< Intermediate buffer (Mx x Ny) for the separable pass.
+		std::vector<double> rowIn;    ///< Reusable row buffer (Nx) for the x-pass.
+		std::vector<double> rowOut;   ///< Reusable resampled row buffer (Mx) for the x-pass.
+		std::vector<double> colIn;    ///< Reusable column buffer (Ny) for the y-pass.
+		std::vector<double> colOut;   ///< Reusable resampled column buffer (My) for the y-pass.
 	public:
 		/// @brief Construct a Resize2D element.
 		/// @param elementCommonParameters  Name, label, and output dimensions (Mx x My).

--- a/dynamic-neural-field-composer/include/user_interface/element_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/element_window.h
@@ -65,6 +65,8 @@ namespace dnf_composer::user_interface
 		static void modifyElementCorrelatedNormalNoise2D(const std::shared_ptr<element::Element>& element);
 		static void modifyElementAsymmetricGaussKernel2D(const std::shared_ptr<element::Element>& element);
 		static void modifyElementMemoryTrace2D(const std::shared_ptr<element::Element>& element);
+		static void modifyElementResize(const std::shared_ptr<element::Element>& element);
+		static void modifyElementResize2D(const std::shared_ptr<element::Element>& element);
 		static ImVec4 getColorForElementType(element::ElementLabel label);
 		static std::string getElementTypeDisplayName(element::ElementLabel label);
 		static PanelScope beginElementPanel(const ImVec4& baseColor, const ImVec2& size);

--- a/dynamic-neural-field-composer/include/user_interface/simulation_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/simulation_window.h
@@ -71,5 +71,7 @@ namespace dnf_composer::user_interface
 		void addElementBoostStimulus2D(char* id, bool addRequested) const;
 		void addElementCorrelatedNormalNoise2D(char* id, bool addRequested) const;
 		void addElementMemoryTrace2D(char* id, bool addRequested) const;
+		void addElementResize(char* id, bool addRequested) const;
+		void addElementResize2D(char* id, bool addRequested) const;
 	};
 }

--- a/dynamic-neural-field-composer/src/elements/element_factory.cpp
+++ b/dynamic-neural-field-composer/src/elements/element_factory.cpp
@@ -157,6 +157,18 @@ namespace dnf_composer
 					return std::make_shared<MemoryTrace2D>(elementCommonParameters, *params);
 				};
 
+			elementCreators[ElementLabel::RESIZE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
+				{
+					const auto params = dynamic_cast<const ResizeParameters*>(&elementSpecificParameters);
+					return std::make_shared<Resize>(elementCommonParameters, *params);
+				};
+
+			elementCreators[ElementLabel::RESIZE_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
+				{
+					const auto params = dynamic_cast<const Resize2DParameters*>(&elementSpecificParameters);
+					return std::make_shared<Resize2D>(elementCommonParameters, *params);
+				};
+
 			}
 
 		std::shared_ptr<Element> ElementFactory::createElement(ElementLabel type, const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
@@ -226,6 +238,10 @@ namespace dnf_composer
 						return creator->second(ElementCommonParameters(type), AsymmetricGaussKernel2DParameters());
 					case ElementLabel::MEMORY_TRACE_2D:
 						return creator->second(ElementCommonParameters(type), MemoryTrace2DParameters());
+					case ElementLabel::RESIZE:
+						return creator->second(ElementCommonParameters(type), ResizeParameters());
+					case ElementLabel::RESIZE_2D:
+						return creator->second(ElementCommonParameters(type), Resize2DParameters());
 					case ElementLabel::UNINITIALIZED:
 						return nullptr;
 				}

--- a/dynamic-neural-field-composer/src/elements/resize.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize.cpp
@@ -1,0 +1,92 @@
+#include "elements/resize.h"
+
+namespace dnf_composer
+{
+	namespace element
+	{
+		Resize::Resize(const ElementCommonParameters& elementCommonParameters,
+			const ResizeParameters& parameters)
+			: Element(elementCommonParameters), parameters(parameters)
+		{
+			commonParameters.identifiers.label = ElementLabel::RESIZE;
+			components["input"] = std::vector<double>(parameters.inputDimensions.size);
+			components["output"] = std::vector<double>(commonParameters.dimensionParameters.size);
+		}
+
+		void Resize::init()
+		{
+			components["input"].assign(parameters.inputDimensions.size, 0.0);
+			components["output"].assign(commonParameters.dimensionParameters.size, 0.0);
+		}
+
+		void Resize::step(double t, double deltaT)
+		{
+			updateInput();
+
+			const auto& in = components["input"];
+			auto& out = components["output"];
+
+			switch (parameters.method)
+			{
+			case InterpolationMethod::LINEAR:
+				tools::math::resampleInto(in, out);
+				break;
+			case InterpolationMethod::NEAREST:
+				tools::math::resampleNearestInto(in, out);
+				break;
+			case InterpolationMethod::CUBIC:
+				tools::math::resampleCubicInto(in, out);
+				break;
+			}
+		}
+
+		void Resize::addInput(const std::shared_ptr<Element>& inputElement,
+			const std::string& inputComponent)
+		{
+			if (!inputElement)
+			{
+				log(tools::logger::LogLevel::ERROR, "Input is null.");
+				return;
+			}
+
+			// Size the input buffer to the source's output size (N may differ from the
+			// output size M) before delegating, so the base size check passes and the
+			// input cache is invalidated correctly.
+			parameters.inputDimensions = inputElement->getElementCommonParameters().dimensionParameters;
+			components["input"].assign(inputElement->getComponentPtr("output")->size(), 0.0);
+
+			Element::addInput(inputElement, inputComponent);
+		}
+
+		std::string Resize::toString() const
+		{
+			std::string result = "Resize element\n";
+			result += commonParameters.toString() + '\n';
+			result += parameters.toString();
+			return result;
+		}
+
+		std::shared_ptr<Element> Resize::clone() const
+		{
+			return std::make_shared<Resize>(*this);
+		}
+
+		void Resize::changeInputDimensions(const ElementDimensions& newInputDimensions)
+		{
+			parameters.inputDimensions = newInputDimensions;
+			components["input"].assign(newInputDimensions.size, 0.0);
+			init();
+		}
+
+		void Resize::setParameters(const ResizeParameters& p)
+		{
+			parameters = p;
+			init();
+		}
+
+		ResizeParameters Resize::getParameters() const
+		{
+			return parameters;
+		}
+	}
+}

--- a/dynamic-neural-field-composer/src/elements/resize.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize.cpp
@@ -49,6 +49,16 @@ namespace dnf_composer
 				return;
 			}
 
+			// Resize accepts exactly one input: it resamples a single source field.
+			// Allowing a second (possibly larger) input would let updateInput() write
+			// past the resized "input" buffer. Reject any additional input.
+			if (!inputs.empty())
+			{
+				log(tools::logger::LogLevel::ERROR, "Resize '" + this->getUniqueName()
+					+ "' already has an input; only one input is allowed.");
+				return;
+			}
+
 			// Size the input buffer to the source's output size (N may differ from the
 			// output size M) before delegating, so the base size check passes and the
 			// input cache is invalidated correctly.

--- a/dynamic-neural-field-composer/src/elements/resize_2d.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize_2d.cpp
@@ -38,6 +38,17 @@ namespace dnf_composer
 		{
 			components["input"].assign(parameters.inputDimensions.size, 0.0);
 			components["output"].assign(commonParameters.dimensionParameters.size, 0.0);
+
+			// Pre-size the separable-pass scratch buffers so step() does no heap allocation.
+			const int inSizeX = parameters.inputDimensions.size_x;
+			const int inSizeY = parameters.inputDimensions.size_y;
+			const int outSizeX = commonParameters.dimensionParameters.size_x;
+			const int outSizeY = commonParameters.dimensionParameters.size_y;
+			scratch.assign(static_cast<std::size_t>(outSizeX) * inSizeY, 0.0);
+			rowIn.assign(inSizeX, 0.0);
+			rowOut.assign(outSizeX, 0.0);
+			colIn.assign(inSizeY, 0.0);
+			colOut.assign(outSizeY, 0.0);
 		}
 
 		void Resize2D::step(double t, double deltaT)
@@ -53,8 +64,6 @@ namespace dnf_composer
 			const int outSizeY = commonParameters.dimensionParameters.size_y;
 
 			// Pass 1: resample each row along x (inSizeX -> outSizeX) into scratch (outSizeX x inSizeY).
-			scratch.assign(static_cast<std::size_t>(outSizeX) * inSizeY, 0.0);
-			std::vector<double> rowIn(inSizeX), rowOut(outSizeX);
 			for (int y = 0; y < inSizeY; ++y)
 			{
 				for (int x = 0; x < inSizeX; ++x)
@@ -65,7 +74,6 @@ namespace dnf_composer
 			}
 
 			// Pass 2: resample each column along y (inSizeY -> outSizeY) into out (outSizeX x outSizeY).
-			std::vector<double> colIn(inSizeY), colOut(outSizeY);
 			for (int x = 0; x < outSizeX; ++x)
 			{
 				for (int y = 0; y < inSizeY; ++y)
@@ -82,6 +90,16 @@ namespace dnf_composer
 			if (!inputElement)
 			{
 				log(tools::logger::LogLevel::ERROR, "Input is null.");
+				return;
+			}
+
+			// Resize2D accepts exactly one input: it resamples a single source field.
+			// Allowing a second (possibly larger) input would let updateInput() write
+			// past the resized "input" buffer. Reject any additional input.
+			if (!inputs.empty())
+			{
+				log(tools::logger::LogLevel::ERROR, "Resize2D '" + this->getUniqueName()
+					+ "' already has an input; only one input is allowed.");
 				return;
 			}
 

--- a/dynamic-neural-field-composer/src/elements/resize_2d.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize_2d.cpp
@@ -1,0 +1,127 @@
+#include "elements/resize_2d.h"
+
+namespace dnf_composer
+{
+	namespace element
+	{
+		namespace
+		{
+			// Resample a 1D buffer according to the selected interpolation method.
+			void resample1d(const std::vector<double>& in, std::vector<double>& out,
+				InterpolationMethod method)
+			{
+				switch (method)
+				{
+				case InterpolationMethod::LINEAR:
+					tools::math::resampleInto(in, out);
+					break;
+				case InterpolationMethod::NEAREST:
+					tools::math::resampleNearestInto(in, out);
+					break;
+				case InterpolationMethod::CUBIC:
+					tools::math::resampleCubicInto(in, out);
+					break;
+				}
+			}
+		}
+
+		Resize2D::Resize2D(const ElementCommonParameters& elementCommonParameters,
+			const Resize2DParameters& parameters)
+			: Element(elementCommonParameters), parameters(parameters)
+		{
+			commonParameters.identifiers.label = ElementLabel::RESIZE_2D;
+			components["input"] = std::vector<double>(parameters.inputDimensions.size);
+			components["output"] = std::vector<double>(commonParameters.dimensionParameters.size);
+		}
+
+		void Resize2D::init()
+		{
+			components["input"].assign(parameters.inputDimensions.size, 0.0);
+			components["output"].assign(commonParameters.dimensionParameters.size, 0.0);
+		}
+
+		void Resize2D::step(double t, double deltaT)
+		{
+			updateInput();
+
+			const auto& in = components["input"];
+			auto& out = components["output"];
+
+			const int inSizeX = parameters.inputDimensions.size_x;
+			const int inSizeY = parameters.inputDimensions.size_y;
+			const int outSizeX = commonParameters.dimensionParameters.size_x;
+			const int outSizeY = commonParameters.dimensionParameters.size_y;
+
+			// Pass 1: resample each row along x (inSizeX -> outSizeX) into scratch (outSizeX x inSizeY).
+			scratch.assign(static_cast<std::size_t>(outSizeX) * inSizeY, 0.0);
+			std::vector<double> rowIn(inSizeX), rowOut(outSizeX);
+			for (int y = 0; y < inSizeY; ++y)
+			{
+				for (int x = 0; x < inSizeX; ++x)
+					rowIn[x] = in[static_cast<std::size_t>(y) * inSizeX + x];
+				resample1d(rowIn, rowOut, parameters.method);
+				for (int x = 0; x < outSizeX; ++x)
+					scratch[static_cast<std::size_t>(y) * outSizeX + x] = rowOut[x];
+			}
+
+			// Pass 2: resample each column along y (inSizeY -> outSizeY) into out (outSizeX x outSizeY).
+			std::vector<double> colIn(inSizeY), colOut(outSizeY);
+			for (int x = 0; x < outSizeX; ++x)
+			{
+				for (int y = 0; y < inSizeY; ++y)
+					colIn[y] = scratch[static_cast<std::size_t>(y) * outSizeX + x];
+				resample1d(colIn, colOut, parameters.method);
+				for (int y = 0; y < outSizeY; ++y)
+					out[static_cast<std::size_t>(y) * outSizeX + x] = colOut[y];
+			}
+		}
+
+		void Resize2D::addInput(const std::shared_ptr<Element>& inputElement,
+			const std::string& inputComponent)
+		{
+			if (!inputElement)
+			{
+				log(tools::logger::LogLevel::ERROR, "Input is null.");
+				return;
+			}
+
+			// Size the input buffer to the source's output size before delegating, so the
+			// base size check passes and the input cache is invalidated correctly.
+			parameters.inputDimensions = inputElement->getElementCommonParameters().dimensionParameters;
+			components["input"].assign(inputElement->getComponentPtr("output")->size(), 0.0);
+
+			Element::addInput(inputElement, inputComponent);
+		}
+
+		std::string Resize2D::toString() const
+		{
+			std::string result = "Resize 2D element\n";
+			result += commonParameters.toString() + '\n';
+			result += parameters.toString();
+			return result;
+		}
+
+		std::shared_ptr<Element> Resize2D::clone() const
+		{
+			return std::make_shared<Resize2D>(*this);
+		}
+
+		void Resize2D::changeInputDimensions(const ElementDimensions& newInputDimensions)
+		{
+			parameters.inputDimensions = newInputDimensions;
+			components["input"].assign(newInputDimensions.size, 0.0);
+			init();
+		}
+
+		void Resize2D::setParameters(const Resize2DParameters& p)
+		{
+			parameters = p;
+			init();
+		}
+
+		Resize2DParameters Resize2D::getParameters() const
+		{
+			return parameters;
+		}
+	}
+}

--- a/dynamic-neural-field-composer/src/user_interface/element_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/element_window.cpp
@@ -29,6 +29,8 @@
 #include "elements/correlated_normal_noise_2d.h"
 #include "elements/asymmetric_gauss_kernel_2d.h"
 #include "elements/memory_trace_2d.h"
+#include "elements/resize.h"
+#include "elements/resize_2d.h"
 #include "user_interface/fonts/IconsFontAwesome6.h"
 #include "tools/utils.h"
 
@@ -241,6 +243,8 @@ namespace dnf_composer::user_interface
 				case element::ElementLabel::CORRELATED_NORMAL_NOISE_2D:  return "Noise2D";
 				case element::ElementLabel::ASYMMETRIC_GAUSS_KERNEL_2D:  return "Kernel2D";
 				case element::ElementLabel::MEMORY_TRACE_2D:             return "Memory2D";
+				case element::ElementLabel::RESIZE:                      return "Resize";
+				case element::ElementLabel::RESIZE_2D:                   return "Resize2D";
 				default:                                                 return "Element";
 			}
 		};
@@ -505,6 +509,8 @@ namespace dnf_composer::user_interface
 	void ElementWindow::renderDimensionControls2D(const std::shared_ptr<element::Element>& element) const
 	{
 		const std::string elemId = element->getUniqueName();
+		const element::ElementLabel label = element->getLabel();
+		const bool hasInputDims = label == element::ElementLabel::RESIZE_2D;
 
 		struct Staged2D { float xMax = 0, yMax = 0, dx = 0, dy = 0; };
 		static std::unordered_map<int, Staged2D> staged;
@@ -540,30 +546,90 @@ namespace dnf_composer::user_interface
 			};
 
 			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("x size");
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted(hasInputDims ? "Out x size" : "x size");
 			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
 			ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##xmax", &s.xMax, 1.0f, 1.0f, 10000.0f, "%.1f"); ImGui::PopFont();
 			commitIf();
 
 			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("x step");
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted(hasInputDims ? "Out x step" : "x step");
 			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
 			ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##dx", &s.dx, 0.01f, 0.001f, 10.0f, "%.2f"); ImGui::PopFont();
 			commitIf();
 
 			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("y size");
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted(hasInputDims ? "Out y size" : "y size");
 			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
 			ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##ymax", &s.yMax, 1.0f, 1.0f, 10000.0f, "%.1f"); ImGui::PopFont();
 			commitIf();
 
 			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("y step");
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted(hasInputDims ? "Out y step" : "y step");
 			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
 			ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##dy", &s.dy, 0.01f, 0.001f, 10.0f, "%.2f"); ImGui::PopFont();
 			commitIf();
 
 			ewEndTable();
+		}
+
+		if (hasInputDims)
+		{
+			static std::unordered_map<int, Staged2D> stagedIn;
+			auto& si = stagedIn[id];
+
+			const auto rz = std::dynamic_pointer_cast<element::Resize2D>(element);
+			const auto& inDim = rz->getParameters().inputDimensions;
+			if (si.xMax == 0.0f)
+			{
+				si.xMax = static_cast<float>(inDim.x_max);
+				si.yMax = static_cast<float>(inDim.y_max);
+				si.dx   = static_cast<float>(inDim.d_x);
+				si.dy   = static_cast<float>(inDim.d_y);
+			}
+
+			auto applyInputDim = [&]() {
+				if (!ImGui::IsItemDeactivatedAfterEdit()) return;
+				if (si.xMax <= 0 || si.yMax <= 0 || si.dx <= 0 || si.dy <= 0) return;
+				const element::ElementDimensions newInDim(
+					static_cast<int>(si.xMax), static_cast<int>(si.yMax),
+					static_cast<double>(si.dx), static_cast<double>(si.dy));
+				element->removeInputs();
+				element->removeOutputs();
+				rz->changeInputDimensions(newInDim);
+				si = { static_cast<float>(newInDim.x_max), static_cast<float>(newInDim.y_max),
+				       static_cast<float>(newInDim.d_x),   static_cast<float>(newInDim.d_y) };
+			};
+
+			if (ewBeginTable("##in_dim2d_tbl"))
+			{
+				ewTableSetup();
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("In x size");
+				ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##in_xmax", &si.xMax, 1.0f, 1.0f, 10000.0f, "%.1f"); ImGui::PopFont();
+				applyInputDim();
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("In x step");
+				ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##in_dx", &si.dx, 0.01f, 0.001f, 10.0f, "%.2f"); ImGui::PopFont();
+				applyInputDim();
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("In y size");
+				ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##in_ymax", &si.yMax, 1.0f, 1.0f, 10000.0f, "%.1f"); ImGui::PopFont();
+				applyInputDim();
+
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("In y step");
+				ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+				ImGui::PushFont(g_MonoMediumFont); ImGui::DragFloat("##in_dy", &si.dy, 0.01f, 0.001f, 10.0f, "%.2f"); ImGui::PopFont();
+				applyInputDim();
+
+				ewEndTable();
+			}
 		}
 
 		ImGui::PopID();
@@ -576,7 +642,8 @@ namespace dnf_composer::user_interface
 		const std::string elemId = element->getUniqueName();
 		const element::ElementLabel label = element->getLabel();
 		const bool isCoupling = label == element::ElementLabel::FIELD_COUPLING ||
-		                        label == element::ElementLabel::GAUSS_FIELD_COUPLING;
+		                        label == element::ElementLabel::GAUSS_FIELD_COUPLING ||
+		                        label == element::ElementLabel::RESIZE;
 
 		static std::unordered_map<int, std::pair<float, float>> staged;
 		static std::unordered_map<int, std::pair<float, float>> stagedIn;
@@ -649,6 +716,11 @@ namespace dnf_composer::user_interface
 				const auto fc = std::dynamic_pointer_cast<element::FieldCoupling>(element);
 				currentInputDim = fc->getParameters().inputFieldDimensions;
 			}
+			else if (label == element::ElementLabel::RESIZE)
+			{
+				const auto rz = std::dynamic_pointer_cast<element::Resize>(element);
+				currentInputDim = rz->getParameters().inputDimensions;
+			}
 			else
 			{
 				const auto gfc = std::dynamic_pointer_cast<element::GaussFieldCoupling>(element);
@@ -668,6 +740,8 @@ namespace dnf_composer::user_interface
 				element->removeOutputs();
 				if (label == element::ElementLabel::FIELD_COUPLING)
 					std::dynamic_pointer_cast<element::FieldCoupling>(element)->changeInputDimensions(newInDim);
+				else if (label == element::ElementLabel::RESIZE)
+					std::dynamic_pointer_cast<element::Resize>(element)->changeInputDimensions(newInDim);
 				else
 					std::dynamic_pointer_cast<element::GaussFieldCoupling>(element)->changeInputDimensions(newInDim);
 				stagedInXmax = static_cast<float>(newInDim.x_max);
@@ -779,6 +853,12 @@ namespace dnf_composer::user_interface
 			break;
 		case element::ElementLabel::MEMORY_TRACE_2D:
 			modifyElementMemoryTrace2D(element);
+			break;
+		case element::ElementLabel::RESIZE:
+			modifyElementResize(element);
+			break;
+		case element::ElementLabel::RESIZE_2D:
+			modifyElementResize2D(element);
 			break;
 		case element::ElementLabel::UNINITIALIZED:
 			break;
@@ -1781,6 +1861,72 @@ namespace dnf_composer::user_interface
 			{ p.tauBuild = tauBuild; p.tauDecay = tauDecay; p.threshold = threshold; mt->setParameters(p); }
 	}
 
+	void ElementWindow::modifyElementResize(const std::shared_ptr<element::Element>& element)
+	{
+		const auto resize = std::dynamic_pointer_cast<element::Resize>(element);
+		element::ResizeParameters p = resize->getParameters();
+		const std::string uid = element->getUniqueName();
+
+		ewSectionLabel("Parameters");
+		if (ewBeginTable(("##rz_tbl" + uid).c_str())) {
+			ewTableSetup();
+
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("Interpolation");
+			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+			if (ImGui::BeginCombo(("##rz_im" + uid).c_str(),
+				element::InterpolationMethodToString.at(p.method).c_str()))
+			{
+				for (size_t i = 0; i < element::InterpolationMethodToString.size(); ++i)
+				{
+					const auto method = static_cast<element::InterpolationMethod>(i);
+					const char* name = element::InterpolationMethodToString.at(method).c_str();
+					if (ImGui::Selectable(name, p.method == method))
+					{
+						p.method = method;
+						resize->setParameters(p);
+					}
+				}
+				ImGui::EndCombo();
+			}
+
+			ewEndTable();
+		}
+	}
+
+	void ElementWindow::modifyElementResize2D(const std::shared_ptr<element::Element>& element)
+	{
+		const auto resize = std::dynamic_pointer_cast<element::Resize2D>(element);
+		element::Resize2DParameters p = resize->getParameters();
+		const std::string uid = element->getUniqueName();
+
+		ewSectionLabel("Parameters");
+		if (ewBeginTable(("##rz2_tbl" + uid).c_str())) {
+			ewTableSetup();
+
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("Interpolation");
+			ImGui::TableSetColumnIndex(1); ImGui::SetNextItemWidth(-FLT_MIN);
+			if (ImGui::BeginCombo(("##rz2_im" + uid).c_str(),
+				element::InterpolationMethodToString.at(p.method).c_str()))
+			{
+				for (size_t i = 0; i < element::InterpolationMethodToString.size(); ++i)
+				{
+					const auto method = static_cast<element::InterpolationMethod>(i);
+					const char* name = element::InterpolationMethodToString.at(method).c_str();
+					if (ImGui::Selectable(name, p.method == method))
+					{
+						p.method = method;
+						resize->setParameters(p);
+					}
+				}
+				ImGui::EndCombo();
+			}
+
+			ewEndTable();
+		}
+	}
+
 	void ElementWindow::modifyElementMemoryTrace(const std::shared_ptr<element::Element>& element)
 	{
 		const auto memoryTrace = std::dynamic_pointer_cast<element::MemoryTrace>(element);
@@ -2141,6 +2287,10 @@ namespace dnf_composer::user_interface
 			return ImVec4(0.506f, 0.608f, 0.622f, 1.0f);  // Deeper Soft Teal
 		case element::ElementLabel::MEMORY_TRACE_2D:
 			return ImVec4(0.376f, 0.545f, 0.478f, 1.0f);  // Deeper Sage Green
+		case element::ElementLabel::RESIZE:
+			return ImVec4(0.500f, 0.600f, 0.700f, 1.0f);  // Steel Blue
+		case element::ElementLabel::RESIZE_2D:
+			return ImVec4(0.420f, 0.510f, 0.600f, 1.0f);  // Deeper Steel Blue
 		default:
 			return ImVec4(0.498f, 0.498f, 0.498f, 1.0f);  // Neutral Gray
 		}
@@ -2174,6 +2324,8 @@ namespace dnf_composer::user_interface
 		case element::ElementLabel::CORRELATED_NORMAL_NOISE_2D: return "Correlated Normal Noise 2D";
 		case element::ElementLabel::ASYMMETRIC_GAUSS_KERNEL_2D: return "Asymmetric Gauss Kernels 2D";
 		case element::ElementLabel::MEMORY_TRACE_2D:         return "Memory Traces 2D";
+		case element::ElementLabel::RESIZE:                  return "Resize";
+		case element::ElementLabel::RESIZE_2D:               return "Resize 2D";
 		default: return "Unknown Elements";
 		}
 	}

--- a/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
@@ -2,6 +2,8 @@
 #include <cstring>
 
 #include "elements/correlated_normal_noise_2d.h"
+#include "elements/resize.h"
+#include "elements/resize_2d.h"
 #include "user_interface/fonts/IconsFontAwesome6.h"
 
 namespace dnf_composer::user_interface
@@ -1028,6 +1030,8 @@ namespace dnf_composer::user_interface
 			return 1;
 		case element::ElementLabel::FIELD_COUPLING:
 		case element::ElementLabel::GAUSS_FIELD_COUPLING:
+		case element::ElementLabel::RESIZE:
+		case element::ElementLabel::RESIZE_2D:
 			return 2;
 		case element::ElementLabel::NEURAL_FIELD:
 		case element::ElementLabel::NEURAL_FIELD_2D:
@@ -1309,6 +1313,22 @@ namespace dnf_composer::user_interface
 			ImGui::Text("Tau build: %.2f",  p.tauBuild);
 			ImGui::Text("Tau decay: %.2f",  p.tauDecay);
 			ImGui::Text("Threshold: %.2f",  p.threshold);
+			break;
+		}
+		case element::ElementLabel::RESIZE:
+		{
+			const auto rz = std::dynamic_pointer_cast<element::Resize>(element);
+			const auto& p = rz->getParameters();
+			ImGui::Text("Interpolation: %s", element::InterpolationMethodToString.at(p.method).c_str());
+			ImGui::Text("Input size: %d",    p.inputDimensions.size);
+			break;
+		}
+		case element::ElementLabel::RESIZE_2D:
+		{
+			const auto rz = std::dynamic_pointer_cast<element::Resize2D>(element);
+			const auto& p = rz->getParameters();
+			ImGui::Text("Interpolation: %s", element::InterpolationMethodToString.at(p.method).c_str());
+			ImGui::Text("Input size: %d x %d", p.inputDimensions.size_x, p.inputDimensions.size_y);
 			break;
 		}
 		default:

--- a/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
@@ -238,13 +238,15 @@ namespace dnf_composer::user_interface
 				L::NEURAL_FIELD, L::GAUSS_STIMULUS, L::TIMED_GAUSS_STIMULUS,
 				L::GAUSS_KERNEL, L::MEXICAN_HAT_KERNEL, L::OSCILLATORY_KERNEL,
 				L::ASYMMETRIC_GAUSS_KERNEL, L::NORMAL_NOISE, L::CORRELATED_NORMAL_NOISE,
-				L::FIELD_COUPLING, L::GAUSS_FIELD_COUPLING, L::BOOST_STIMULUS, L::MEMORY_TRACE
+				L::FIELD_COUPLING, L::GAUSS_FIELD_COUPLING, L::BOOST_STIMULUS, L::MEMORY_TRACE,
+				L::RESIZE
 			};
 			static constexpr L k2D[] = {
 				L::NEURAL_FIELD_2D, L::GAUSS_STIMULUS_2D, L::TIMED_GAUSS_STIMULUS_2D,
 				L::GAUSS_KERNEL_2D, L::MEXICAN_HAT_KERNEL_2D, L::OSCILLATORY_KERNEL_2D,
 				L::ASYMMETRIC_GAUSS_KERNEL_2D, L::NORMAL_NOISE_2D, L::CORRELATED_NORMAL_NOISE_2D,
-				L::BOOST_STIMULUS_2D, L::MEMORY_TRACE_2D
+				L::BOOST_STIMULUS_2D, L::MEMORY_TRACE_2D,
+				L::RESIZE_2D
 			};
 			const L* pLabels = (dimensionality == 1) ? k1D : k2D;
 			const int nLabels = (dimensionality == 1) ? static_cast<int>(std::size(k1D))
@@ -316,6 +318,8 @@ namespace dnf_composer::user_interface
 			case element::ElementLabel::BOOST_STIMULUS_2D:          addElementBoostStimulus2D(id, addRequested);        break;
 			case element::ElementLabel::CORRELATED_NORMAL_NOISE_2D: addElementCorrelatedNormalNoise2D(id, addRequested); break;
 			case element::ElementLabel::MEMORY_TRACE_2D:            addElementMemoryTrace2D(id, addRequested);          break;
+			case element::ElementLabel::RESIZE:                     addElementResize(id, addRequested);                  break;
+			case element::ElementLabel::RESIZE_2D:                  addElementResize2D(id, addRequested);                break;
 			default: break;
 		}
 
@@ -1424,6 +1428,112 @@ namespace dnf_composer::user_interface
 			const element::MemoryTrace2DParameters mtp{ tauBuild, tauDecay, threshold };
 			const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max, y_max, d_x, d_y } };
 			simulation->addElement(std::make_shared<element::MemoryTrace2D>(common, mtp));
+		}
+	}
+
+	void SimulationWindow::addElementResize(char* id, bool addRequested) const
+	{
+		static int    x_max_out = 100;
+		static double d_x_out   = 1.0;
+		static int    x_max_in  = 100;
+		static double d_x_in    = 1.0;
+		static auto   method    = element::InterpolationMethod::LINEAR;
+
+		ImGui::SeparatorText("Output dimensions");
+		if (beginParamTable("##rz_odim")) {
+			paramTableSetup();
+			paramRowInt   ("Size", "##rz_osize", &x_max_out);
+			paramRowDouble("Step", "##rz_ostep", &d_x_out, "%.2f");
+			endParamTable();
+		}
+		ImGui::SeparatorText("Input dimensions");
+		if (beginParamTable("##rz_idim")) {
+			paramTableSetup();
+			paramRowInt   ("Size", "##rz_isize", &x_max_in);
+			paramRowDouble("Step", "##rz_istep", &d_x_in, "%.2f");
+			endParamTable();
+		}
+		ImGui::SeparatorText("Interpolation");
+		if (beginParamTable("##rz_interp")) {
+			paramTableSetup();
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("Method");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-FLT_MIN);
+			if (ImGui::BeginCombo("##rz_method", element::InterpolationMethodToString.at(method).c_str()))
+			{
+				for (const auto& [m, name] : element::InterpolationMethodToString)
+				{
+					const bool sel = (method == m);
+					if (ImGui::Selectable(name.c_str(), sel)) method = m;
+					if (sel) ImGui::SetItemDefaultFocus();
+				}
+				ImGui::EndCombo();
+			}
+			endParamTable();
+		}
+
+		if (addRequested)
+		{
+			const element::ElementDimensions inDims{ x_max_in, d_x_in };
+			const element::ResizeParameters rp{ method, inDims };
+			const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max_out, d_x_out } };
+			simulation->addElement(std::make_shared<element::Resize>(common, rp));
+		}
+	}
+
+	void SimulationWindow::addElementResize2D(char* id, bool addRequested) const
+	{
+		static int    x_max_out = 50, y_max_out = 50;
+		static double d_x_out = 1.0, d_y_out = 1.0;
+		static int    x_max_in = 50, y_max_in = 50;
+		static double d_x_in = 1.0, d_y_in = 1.0;
+		static auto   method = element::InterpolationMethod::LINEAR;
+
+		ImGui::SeparatorText("Output dimensions");
+		if (beginParamTable("##rz2_odim")) {
+			paramTableSetup();
+			paramRowInt   ("x size", "##rz2_oxmax", &x_max_out);
+			paramRowInt   ("y size", "##rz2_oymax", &y_max_out);
+			paramRowDouble("x step", "##rz2_odx",   &d_x_out, "%.2f");
+			paramRowDouble("y step", "##rz2_ody",   &d_y_out, "%.2f");
+			endParamTable();
+		}
+		ImGui::SeparatorText("Input dimensions");
+		if (beginParamTable("##rz2_idim")) {
+			paramTableSetup();
+			paramRowInt   ("x size", "##rz2_ixmax", &x_max_in);
+			paramRowInt   ("y size", "##rz2_iymax", &y_max_in);
+			paramRowDouble("x step", "##rz2_idx",   &d_x_in, "%.2f");
+			paramRowDouble("y step", "##rz2_idy",   &d_y_in, "%.2f");
+			endParamTable();
+		}
+		ImGui::SeparatorText("Interpolation");
+		if (beginParamTable("##rz2_interp")) {
+			paramTableSetup();
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0); ImGui::AlignTextToFramePadding(); ImGui::TextUnformatted("Method");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-FLT_MIN);
+			if (ImGui::BeginCombo("##rz2_method", element::InterpolationMethodToString.at(method).c_str()))
+			{
+				for (const auto& [m, name] : element::InterpolationMethodToString)
+				{
+					const bool sel = (method == m);
+					if (ImGui::Selectable(name.c_str(), sel)) method = m;
+					if (sel) ImGui::SetItemDefaultFocus();
+				}
+				ImGui::EndCombo();
+			}
+			endParamTable();
+		}
+
+		if (addRequested)
+		{
+			const element::ElementDimensions inDims{ x_max_in, y_max_in, d_x_in, d_y_in };
+			const element::Resize2DParameters rp{ method, inDims };
+			const element::ElementCommonParameters common{ std::string(id), element::ElementDimensions{ x_max_out, y_max_out, d_x_out, d_y_out } };
+			simulation->addElement(std::make_shared<element::Resize2D>(common, rp));
 		}
 	}
 

--- a/dynamic-neural-field-composer/tests/CMakeLists.txt
+++ b/dynamic-neural-field-composer/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "elements/test_memory_trace_2d.cpp"
             "elements/test_mexican_hat_kernel_2d.cpp"
             "elements/test_change_dimensions.cpp"
+            "elements/test_resize.cpp"
+            "elements/test_resize_2d.cpp"
             # simulation
             "simulation/test_simulation.cpp"
             "simulation/test_simulation_extended.cpp"

--- a/dynamic-neural-field-composer/tests/elements/test_resize.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize.cpp
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "elements/resize.h"
+#include "elements/gauss_stimulus.h"
+
+using namespace dnf_composer;
+using namespace dnf_composer::element;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::shared_ptr<Resize> makeResize(const std::string& name,
+    const int inSize, const int outSize,
+    const InterpolationMethod method = InterpolationMethod::LINEAR)
+{
+    const ElementDimensions inDim{ inSize, 1.0 };
+    const ResizeParameters rp{ method, inDim };
+    const ElementCommonParameters cp{ name, ElementDimensions{ outSize, 1.0 } };
+    return std::make_shared<Resize>(cp, rp);
+}
+
+// A generic source of a given size whose "output" we overwrite with a known vector.
+static std::shared_ptr<GaussStimulus> makeSource(const std::string& name, const int size)
+{
+    const GaussStimulusParameters gp{};
+    const ElementCommonParameters cp{ name, ElementDimensions{ size, 1.0 } };
+    return std::make_shared<GaussStimulus>(cp, gp);
+}
+
+// Connect a source of the given values to a Resize, step it, and return the output.
+static std::vector<double> resampleVia(const std::shared_ptr<Resize>& resize,
+    const std::vector<double>& input)
+{
+    const auto source = makeSource("src", static_cast<int>(input.size()));
+    source->init();
+    resize->addInput(source);
+    resize->init();
+
+    // Overwrite the source output in place with the known input vector. Writing in
+    // place (rather than reassigning) keeps the buffer address stable; step() builds
+    // the input cache lazily on first call.
+    auto* out = source->getComponentPtr("output");
+    std::copy(input.begin(), input.end(), out->begin());
+
+    resize->step(0.0, 1.0);
+    return resize->getComponent("output");
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+TEST(ResizeTest, ConstructionDoesNotThrow)
+{
+    EXPECT_NO_THROW(makeResize("rz", 50, 100));
+}
+
+TEST(ResizeTest, HasCorrectLabel)
+{
+    const auto rz = makeResize("rz", 50, 100);
+    EXPECT_EQ(rz->getLabel(), ElementLabel::RESIZE);
+}
+
+TEST(ResizeTest, OutputSizeMatchesDeclaredDimension)
+{
+    const auto rz = makeResize("rz", 50, 80);
+    rz->init();
+    EXPECT_EQ(static_cast<int>(rz->getComponent("output").size()), 80);
+}
+
+TEST(ResizeTest, InputSizeMatchesInputDimensions)
+{
+    const auto rz = makeResize("rz", 37, 80);
+    rz->init();
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 37);
+}
+
+// ---------------------------------------------------------------------------
+// addInput resizes the input buffer to the source size
+// ---------------------------------------------------------------------------
+
+TEST(ResizeTest, AddInputResizesInputBuffer)
+{
+    const auto rz = makeResize("rz", 10, 80); // declared input size 10 ...
+    const auto source = makeSource("src", 25); // ... but source is size 25
+    source->init();
+    rz->addInput(source);
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 25);
+    EXPECT_EQ(rz->getParameters().inputDimensions.size, 25);
+}
+
+// ---------------------------------------------------------------------------
+// Numerical correctness
+// ---------------------------------------------------------------------------
+
+TEST(ResizeTest, IdentityWhenSizesEqual)
+{
+    const auto rz = makeResize("rz", 4, 4, InterpolationMethod::LINEAR);
+    const std::vector<double> in{ 1.0, 2.0, 3.0, 4.0 };
+    const auto out = resampleVia(rz, in);
+    ASSERT_EQ(out.size(), in.size());
+    for (size_t i = 0; i < in.size(); ++i)
+        EXPECT_DOUBLE_EQ(out[i], in[i]);
+}
+
+TEST(ResizeTest, LinearUpsampleOfRamp)
+{
+    // Ramp input 0..3 (N=4) upsampled to M=7.
+    // pos_i = i * (N-1)/(M-1) = i * 3/6 = 0.5 i; for a ramp, value == position.
+    const auto rz = makeResize("rz", 4, 7, InterpolationMethod::LINEAR);
+    const std::vector<double> in{ 0.0, 1.0, 2.0, 3.0 };
+    const auto out = resampleVia(rz, in);
+    ASSERT_EQ(out.size(), 7u);
+    for (int i = 0; i < 7; ++i)
+        EXPECT_NEAR(out[i], 0.5 * i, 1e-9);
+}
+
+TEST(ResizeTest, LinearDownsampleEndpointsPreserved)
+{
+    // Endpoints are always preserved by the linear resampler.
+    const auto rz = makeResize("rz", 9, 5, InterpolationMethod::LINEAR);
+    std::vector<double> in(9);
+    for (int i = 0; i < 9; ++i) in[i] = static_cast<double>(i); // ramp 0..8
+    const auto out = resampleVia(rz, in);
+    ASSERT_EQ(out.size(), 5u);
+    // pos_i = i * 8/4 = 2 i -> ramp value 2 i
+    for (int i = 0; i < 5; ++i)
+        EXPECT_NEAR(out[i], 2.0 * i, 1e-9);
+}
+
+TEST(ResizeTest, NearestNeighbourPicksClosestSample)
+{
+    // N=3 -> M=5, pos_i = i * 2/4 = 0.5 i; round(0.5 i) selects nearest index.
+    const auto rz = makeResize("rz", 3, 5, InterpolationMethod::NEAREST);
+    const std::vector<double> in{ 10.0, 20.0, 30.0 };
+    const auto out = resampleVia(rz, in);
+    ASSERT_EQ(out.size(), 5u);
+    // pos: 0, 0.5, 1.0, 1.5, 2.0 -> round: 0, 0(.5->0 via std::round? 0.5 rounds to 1)
+    // std::round(0.5) = 1, std::round(1.5) = 2
+    EXPECT_DOUBLE_EQ(out[0], in[0]); // pos 0 -> idx 0
+    EXPECT_DOUBLE_EQ(out[2], in[1]); // pos 1.0 -> idx 1
+    EXPECT_DOUBLE_EQ(out[4], in[2]); // pos 2.0 -> idx 2
+}
+
+TEST(ResizeTest, CubicReproducesLinearDataAtSamplePoints)
+{
+    // For a linear ramp, Catmull-Rom cubic reproduces the linear values exactly.
+    const auto rz = makeResize("rz", 5, 9, InterpolationMethod::CUBIC);
+    std::vector<double> in(5);
+    for (int i = 0; i < 5; ++i) in[i] = static_cast<double>(i);
+    const auto out = resampleVia(rz, in);
+    ASSERT_EQ(out.size(), 9u);
+    // pos_i = i * 4/8 = 0.5 i ; ramp value == position
+    for (int i = 0; i < 9; ++i)
+        EXPECT_NEAR(out[i], 0.5 * i, 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Parameter update
+// ---------------------------------------------------------------------------
+
+TEST(ResizeTest, SetParametersChangesMethod)
+{
+    const auto rz = makeResize("rz", 3, 5, InterpolationMethod::LINEAR);
+    ResizeParameters p = rz->getParameters();
+    p.method = InterpolationMethod::NEAREST;
+    rz->setParameters(p);
+    EXPECT_EQ(rz->getParameters().method, InterpolationMethod::NEAREST);
+}
+
+// ---------------------------------------------------------------------------
+// toString / clone
+// ---------------------------------------------------------------------------
+
+TEST(ResizeTest, ToStringReturnsNonEmpty)
+{
+    const auto rz = makeResize("rz", 50, 100);
+    EXPECT_FALSE(rz->toString().empty());
+}
+
+TEST(ResizeTest, CloneProducesIdenticalOutput)
+{
+    const auto rz = makeResize("rz", 4, 7, InterpolationMethod::LINEAR);
+    const std::vector<double> in{ 0.0, 1.0, 2.0, 3.0 };
+    const auto out = resampleVia(rz, in);
+
+    const auto clone = std::dynamic_pointer_cast<Resize>(rz->clone());
+    ASSERT_NE(clone, nullptr);
+    const auto cloneOut = resampleVia(clone, in);
+
+    ASSERT_EQ(out.size(), cloneOut.size());
+    for (size_t i = 0; i < out.size(); ++i)
+        EXPECT_DOUBLE_EQ(out[i], cloneOut[i]);
+}
+
+// ---------------------------------------------------------------------------
+// Parameters equality / toString
+// ---------------------------------------------------------------------------
+
+TEST(ResizeParametersTest, EqualParametersCompareEqual)
+{
+    const ElementDimensions dim{ 50, 1.0 };
+    const ResizeParameters a{ InterpolationMethod::LINEAR, dim };
+    const ResizeParameters b{ InterpolationMethod::LINEAR, dim };
+    EXPECT_EQ(a, b);
+}
+
+TEST(ResizeParametersTest, DifferentMethodComparesNotEqual)
+{
+    const ElementDimensions dim{ 50, 1.0 };
+    const ResizeParameters a{ InterpolationMethod::LINEAR,  dim };
+    const ResizeParameters b{ InterpolationMethod::NEAREST, dim };
+    EXPECT_NE(a, b);
+}

--- a/dynamic-neural-field-composer/tests/elements/test_resize.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize.cpp
@@ -22,9 +22,11 @@ static std::shared_ptr<Resize> makeResize(const std::string& name,
 }
 
 // A generic source of a given size whose "output" we overwrite with a known vector.
+// position 0.0 keeps the Gaussian centre in range even for tiny test fields (the
+// actual profile is irrelevant — it is overwritten before stepping).
 static std::shared_ptr<GaussStimulus> makeSource(const std::string& name, const int size)
 {
-    const GaussStimulusParameters gp{};
+    const GaussStimulusParameters gp{ 1.0, 1.0, 0.0 };
     const ElementCommonParameters cp{ name, ElementDimensions{ size, 1.0 } };
     return std::make_shared<GaussStimulus>(cp, gp);
 }
@@ -144,17 +146,24 @@ TEST(ResizeTest, NearestNeighbourPicksClosestSample)
     EXPECT_DOUBLE_EQ(out[4], in[2]); // pos 2.0 -> idx 2
 }
 
-TEST(ResizeTest, CubicReproducesLinearDataAtSamplePoints)
+TEST(ResizeTest, CubicReproducesSampleValuesAtAlignedPositions)
 {
-    // For a linear ramp, Catmull-Rom cubic reproduces the linear values exactly.
+    // N=5 -> M=9, pos_i = i * 4/8 = 0.5 i. At even output indices the position is an
+    // integer, so the output must equal the original sample exactly (any interpolation
+    // passes through the sample points). Odd indices fall between samples; for the
+    // interior intervals Catmull-Rom reproduces a linear ramp, but the boundary
+    // intervals use clamped endpoints and are not exactly linear, so we don't assert
+    // those.
     const auto rz = makeResize("rz", 5, 9, InterpolationMethod::CUBIC);
     std::vector<double> in(5);
     for (int i = 0; i < 5; ++i) in[i] = static_cast<double>(i);
     const auto out = resampleVia(rz, in);
     ASSERT_EQ(out.size(), 9u);
-    // pos_i = i * 4/8 = 0.5 i ; ramp value == position
-    for (int i = 0; i < 9; ++i)
+    for (int i = 0; i < 9; i += 2)              // aligned sample points
         EXPECT_NEAR(out[i], 0.5 * i, 1e-9);
+    // interior midpoint (between in[1] and in[2]) is exact for Catmull-Rom on a ramp
+    EXPECT_NEAR(out[3], 1.5, 1e-9);
+    EXPECT_NEAR(out[5], 2.5, 1e-9);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,6 +197,10 @@ TEST(ResizeTest, CloneProducesIdenticalOutput)
 
     const auto clone = std::dynamic_pointer_cast<Resize>(rz->clone());
     ASSERT_NE(clone, nullptr);
+    // The clone is a copy and already carries the original's input connection;
+    // clear it so resampleVia wires a single fresh source (otherwise two sources
+    // would be summed, doubling the output).
+    clone->removeInputs();
     const auto cloneOut = resampleVia(clone, in);
 
     ASSERT_EQ(out.size(), cloneOut.size());

--- a/dynamic-neural-field-composer/tests/elements/test_resize.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize.cpp
@@ -93,6 +93,31 @@ TEST(ResizeTest, AddInputResizesInputBuffer)
     EXPECT_EQ(rz->getParameters().inputDimensions.size, 25);
 }
 
+// Regression: Resize is single-input. A second input must be rejected so that the
+// resized "input" buffer cannot be overrun by a larger second source in step().
+TEST(ResizeTest, SecondInputIsRejected)
+{
+    const auto rz = makeResize("rz", 25, 80);
+    const auto first  = makeSource("first", 25);
+    const auto second = makeSource("second", 40);
+    first->init();
+    second->init();
+
+    rz->addInput(first);
+    rz->addInput(second); // must be refused
+
+    EXPECT_EQ(rz->getInputs().size(), 1u);
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 25);
+
+    // step() must not read/write out of bounds and must reflect only the first source.
+    rz->init();
+    auto* out = first->getComponentPtr("output");
+    std::fill(out->begin(), out->end(), 1.0);
+    EXPECT_NO_THROW(rz->step(0.0, 1.0));
+    for (const double v : rz->getComponent("output"))
+        EXPECT_DOUBLE_EQ(v, 1.0); // resampling a constant field yields the same constant
+}
+
 // ---------------------------------------------------------------------------
 // Numerical correctness
 // ---------------------------------------------------------------------------

--- a/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
@@ -87,6 +87,30 @@ TEST(Resize2DTest, AddInputResizesInputBuffer)
     EXPECT_EQ(rz->getParameters().inputDimensions.size_y, 6);
 }
 
+// Regression: Resize2D is single-input. A second input must be rejected so that the
+// resized "input" buffer cannot be overrun by a larger second source in step().
+TEST(Resize2DTest, SecondInputIsRejected)
+{
+    const auto rz = makeResize2D("rz", 8, 6, 40, 40);
+    const auto first  = makeSource2D("first", 8, 6);
+    const auto second = makeSource2D("second", 12, 10);
+    first->init();
+    second->init();
+
+    rz->addInput(first);
+    rz->addInput(second); // must be refused
+
+    EXPECT_EQ(rz->getInputs().size(), 1u);
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 8 * 6);
+
+    rz->init();
+    auto* out = first->getComponentPtr("output");
+    std::fill(out->begin(), out->end(), 1.0);
+    EXPECT_NO_THROW(rz->step(0.0, 1.0));
+    for (const double v : rz->getComponent("output"))
+        EXPECT_DOUBLE_EQ(v, 1.0);
+}
+
 // ---------------------------------------------------------------------------
 // Numerical correctness
 // ---------------------------------------------------------------------------

--- a/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
@@ -21,10 +21,12 @@ static std::shared_ptr<Resize2D> makeResize2D(const std::string& name,
     return std::make_shared<Resize2D>(cp, rp);
 }
 
+// position (0,0) keeps the Gaussian centre in range even for tiny test fields
+// (the actual profile is irrelevant — it is overwritten before stepping).
 static std::shared_ptr<GaussStimulus2D> makeSource2D(const std::string& name,
     const int sizeX, const int sizeY)
 {
-    const GaussStimulus2DParameters gp{};
+    const GaussStimulus2DParameters gp{ 1.0, 1.0, 0.0, 0.0 };
     const ElementCommonParameters cp{ name, ElementDimensions{ sizeX, sizeY, 1.0, 1.0 } };
     return std::make_shared<GaussStimulus2D>(cp, gp);
 }
@@ -156,6 +158,9 @@ TEST(Resize2DTest, CloneProducesIdenticalOutput)
 
     const auto clone = std::dynamic_pointer_cast<Resize2D>(rz->clone());
     ASSERT_NE(clone, nullptr);
+    // The clone copies the original's input connection; clear it so resampleVia
+    // wires a single fresh source (otherwise two sources would be summed).
+    clone->removeInputs();
     const auto cloneOut = resampleVia(clone, field, 2, 2);
 
     ASSERT_EQ(out.size(), cloneOut.size());

--- a/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_resize_2d.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "elements/resize_2d.h"
+#include "elements/gauss_stimulus_2d.h"
+
+using namespace dnf_composer;
+using namespace dnf_composer::element;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::shared_ptr<Resize2D> makeResize2D(const std::string& name,
+    const int inX, const int inY, const int outX, const int outY,
+    const InterpolationMethod method = InterpolationMethod::LINEAR)
+{
+    const ElementDimensions inDim{ inX, inY, 1.0, 1.0 };
+    const Resize2DParameters rp{ method, inDim };
+    const ElementCommonParameters cp{ name, ElementDimensions{ outX, outY, 1.0, 1.0 } };
+    return std::make_shared<Resize2D>(cp, rp);
+}
+
+static std::shared_ptr<GaussStimulus2D> makeSource2D(const std::string& name,
+    const int sizeX, const int sizeY)
+{
+    const GaussStimulus2DParameters gp{};
+    const ElementCommonParameters cp{ name, ElementDimensions{ sizeX, sizeY, 1.0, 1.0 } };
+    return std::make_shared<GaussStimulus2D>(cp, gp);
+}
+
+// Connect a known y-major field to a Resize2D, step, and return the output.
+static std::vector<double> resampleVia(const std::shared_ptr<Resize2D>& resize,
+    const std::vector<double>& field, const int sizeX, const int sizeY)
+{
+    const auto source = makeSource2D("src", sizeX, sizeY);
+    source->init();
+    resize->addInput(source);
+    resize->init();
+
+    auto* out = source->getComponentPtr("output");
+    std::copy(field.begin(), field.end(), out->begin());
+
+    resize->step(0.0, 1.0);
+    return resize->getComponent("output");
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+TEST(Resize2DTest, ConstructionDoesNotThrow)
+{
+    EXPECT_NO_THROW(makeResize2D("rz", 20, 20, 40, 40));
+}
+
+TEST(Resize2DTest, HasCorrectLabel)
+{
+    const auto rz = makeResize2D("rz", 20, 20, 40, 40);
+    EXPECT_EQ(rz->getLabel(), ElementLabel::RESIZE_2D);
+}
+
+TEST(Resize2DTest, OutputSizeMatchesDeclaredDimension)
+{
+    const auto rz = makeResize2D("rz", 20, 20, 40, 30);
+    rz->init();
+    EXPECT_EQ(static_cast<int>(rz->getComponent("output").size()), 40 * 30);
+}
+
+TEST(Resize2DTest, InputSizeMatchesInputDimensions)
+{
+    const auto rz = makeResize2D("rz", 16, 12, 40, 30);
+    rz->init();
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 16 * 12);
+}
+
+TEST(Resize2DTest, AddInputResizesInputBuffer)
+{
+    const auto rz = makeResize2D("rz", 5, 5, 40, 40);
+    const auto source = makeSource2D("src", 8, 6);
+    source->init();
+    rz->addInput(source);
+    EXPECT_EQ(static_cast<int>(rz->getComponent("input").size()), 8 * 6);
+    EXPECT_EQ(rz->getParameters().inputDimensions.size_x, 8);
+    EXPECT_EQ(rz->getParameters().inputDimensions.size_y, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Numerical correctness
+// ---------------------------------------------------------------------------
+
+TEST(Resize2DTest, IdentityWhenSizesEqual)
+{
+    const auto rz = makeResize2D("rz", 3, 2, 3, 2, InterpolationMethod::LINEAR);
+    // y-major: field[y*3 + x]
+    const std::vector<double> field{ 1, 2, 3,
+                                     4, 5, 6 };
+    const auto out = resampleVia(rz, field, 3, 2);
+    ASSERT_EQ(out.size(), field.size());
+    for (size_t i = 0; i < field.size(); ++i)
+        EXPECT_DOUBLE_EQ(out[i], field[i]);
+}
+
+TEST(Resize2DTest, LinearUpsampleSeparablePlane)
+{
+    // Input 2x2 plane f(x,y) = x + 10*y (y-major), upsampled to 3x3.
+    // Linear separable interpolation of a bilinear plane reproduces the plane.
+    // pos along each axis: i*(N-1)/(M-1) = i*1/2 = 0.5 i
+    const auto rz = makeResize2D("rz", 2, 2, 3, 3, InterpolationMethod::LINEAR);
+    const std::vector<double> field{ 0.0,  1.0,    // y=0: x=0,1
+                                     10.0, 11.0 };  // y=1: x=0,1
+    const auto out = resampleVia(rz, field, 2, 2);
+    ASSERT_EQ(out.size(), 9u);
+    for (int y = 0; y < 3; ++y)
+        for (int x = 0; x < 3; ++x)
+        {
+            const double expected = 0.5 * x + 10.0 * (0.5 * y);
+            EXPECT_NEAR(out[y * 3 + x], expected, 1e-9)
+                << "at x=" << x << " y=" << y;
+        }
+}
+
+TEST(Resize2DTest, NearestNeighbourSeparable)
+{
+    // 2x2 -> 3x3 nearest. pos 0,0.5,1 -> round -> 0,1,1 on each axis.
+    const auto rz = makeResize2D("rz", 2, 2, 3, 3, InterpolationMethod::NEAREST);
+    const std::vector<double> field{ 1.0, 2.0,
+                                     3.0, 4.0 };
+    const auto out = resampleVia(rz, field, 2, 2);
+    ASSERT_EQ(out.size(), 9u);
+    // index map per axis: out 0->in 0, out 1->in 1, out 2->in 1
+    const int mapAxis[3] = { 0, 1, 1 };
+    for (int y = 0; y < 3; ++y)
+        for (int x = 0; x < 3; ++x)
+            EXPECT_DOUBLE_EQ(out[y * 3 + x], field[mapAxis[y] * 2 + mapAxis[x]]);
+}
+
+// ---------------------------------------------------------------------------
+// Parameter update / clone
+// ---------------------------------------------------------------------------
+
+TEST(Resize2DTest, SetParametersChangesMethod)
+{
+    const auto rz = makeResize2D("rz", 4, 4, 8, 8, InterpolationMethod::LINEAR);
+    Resize2DParameters p = rz->getParameters();
+    p.method = InterpolationMethod::CUBIC;
+    rz->setParameters(p);
+    EXPECT_EQ(rz->getParameters().method, InterpolationMethod::CUBIC);
+}
+
+TEST(Resize2DTest, CloneProducesIdenticalOutput)
+{
+    const auto rz = makeResize2D("rz", 2, 2, 3, 3, InterpolationMethod::LINEAR);
+    const std::vector<double> field{ 0.0, 1.0, 10.0, 11.0 };
+    const auto out = resampleVia(rz, field, 2, 2);
+
+    const auto clone = std::dynamic_pointer_cast<Resize2D>(rz->clone());
+    ASSERT_NE(clone, nullptr);
+    const auto cloneOut = resampleVia(clone, field, 2, 2);
+
+    ASSERT_EQ(out.size(), cloneOut.size());
+    for (size_t i = 0; i < out.size(); ++i)
+        EXPECT_DOUBLE_EQ(out[i], cloneOut[i]);
+}
+
+TEST(Resize2DTest, ToStringReturnsNonEmpty)
+{
+    const auto rz = makeResize2D("rz", 20, 20, 40, 40);
+    EXPECT_FALSE(rz->toString().empty());
+}

--- a/dynamic-neural-field-composer/wiki/Application-and-UI.md
+++ b/dynamic-neural-field-composer/wiki/Application-and-UI.md
@@ -149,7 +149,7 @@ app.addWindow<user_interface::SimulationWindow>();
 
 ### ElementWindow
 
-A panel listing all elements in the simulation. Selecting an element shows and allows live editing of its parameters (tau, resting level, kernel widths, etc.) and its spatial dimensions. For kernel elements, **Output Size** and **Output Step** controls are also available to configure cross-dimension output (see [Cross-dimension kernels](Element-Reference#cross-dimension-kernels)). Changing dimensions severs existing connections; reconnect through the NodeGraphWindow or in code.
+A panel listing all elements in the simulation. Selecting an element shows and allows live editing of its parameters (tau, resting level, kernel widths, etc.) and its spatial dimensions. For `Resize` / `Resize2D` elements, separate **Output dimensions** and **Input dimensions** controls are available. Changing dimensions severs existing connections; reconnect through the NodeGraphWindow or in code.
 
 ```cpp
 app.addWindow<user_interface::ElementWindow>();

--- a/dynamic-neural-field-composer/wiki/Element-Reference.md
+++ b/dynamic-neural-field-composer/wiki/Element-Reference.md
@@ -78,12 +78,11 @@ A Gaussian lateral interaction kernel. Typically provides local excitation (posi
 
 ```cpp
 GaussKernelParameters{
-    double width                                       = 3.0,
-    double amplitude                                   = 3.0,
-    double amplitudeGlobal                             = -0.01,
-    bool   circular                                    = true,
-    bool   normalized                                  = true,
-    std::optional<ElementDimensions> outputFieldDimensions = std::nullopt
+    double width           = 3.0,
+    double amplitude       = 3.0,
+    double amplitudeGlobal = -0.01,
+    bool   circular        = true,
+    bool   normalized      = true
 }
 ```
 
@@ -94,7 +93,6 @@ GaussKernelParameters{
 | `amplitudeGlobal` | `-0.01` | Uniform global inhibition added to every position |
 | `circular` | `true` | Whether the field wraps around at the boundaries |
 | `normalized` | `true` | Whether the Gaussian is area-normalized |
-| `outputFieldDimensions` | `nullopt` | When set, the convolution output is resampled to this size — enables cross-dimension connections (see [Cross-dimension kernels](#cross-dimension-kernels)) |
 
 ### Components
 
@@ -115,14 +113,13 @@ A Mexican Hat (difference-of-Gaussians) kernel providing short-range excitation 
 
 ```cpp
 MexicanHatKernelParameters{
-    double widthExc                                        = 2.5,
-    double amplitudeExc                                    = 11.0,
-    double widthInh                                        = 5.0,
-    double amplitudeInh                                    = 15.0,
-    double amplitudeGlobal                                 = -0.1,
-    bool   circular                                        = true,
-    bool   normalized                                      = true,
-    std::optional<ElementDimensions> outputFieldDimensions = std::nullopt
+    double widthExc        = 2.5,
+    double amplitudeExc    = 11.0,
+    double widthInh        = 5.0,
+    double amplitudeInh    = 15.0,
+    double amplitudeGlobal = -0.1,
+    bool   circular        = true,
+    bool   normalized      = true
 }
 ```
 
@@ -135,7 +132,6 @@ MexicanHatKernelParameters{
 | `amplitudeGlobal` | `-0.1` | Uniform global inhibition |
 | `circular` | `true` | Boundary wrapping |
 | `normalized` | `true` | Area normalization |
-| `outputFieldDimensions` | `nullopt` | When set, the convolution output is resampled to this size — enables cross-dimension connections (see [Cross-dimension kernels](#cross-dimension-kernels)) |
 
 ### Components
 
@@ -156,13 +152,12 @@ A kernel with an oscillatory (damped cosine) lateral interaction pattern. Useful
 
 ```cpp
 OscillatoryKernelParameters{
-    double amplitude                                       = 1.0,
-    double decay                                           = 0.08,   // must be > 0
-    double zeroCrossings                                   = 0.3,    // clamped to [0, 1]
-    double amplitudeGlobal                                 = -0.01,
-    bool   circular                                        = true,
-    bool   normalized                                      = false,
-    std::optional<ElementDimensions> outputFieldDimensions = std::nullopt
+    double amplitude       = 1.0,
+    double decay           = 0.08,   // must be > 0
+    double zeroCrossings   = 0.3,    // clamped to [0, 1]
+    double amplitudeGlobal = -0.01,
+    bool   circular        = true,
+    bool   normalized      = false
 }
 ```
 
@@ -174,7 +169,6 @@ OscillatoryKernelParameters{
 | `amplitudeGlobal` | `-0.01` | Uniform global inhibition |
 | `circular` | `true` | Boundary wrapping |
 | `normalized` | `false` | Area normalization |
-| `outputFieldDimensions` | `nullopt` | When set, the convolution output is resampled to this size — enables cross-dimension connections (see [Cross-dimension kernels](#cross-dimension-kernels)) |
 
 ### Components
 
@@ -195,13 +189,12 @@ A Gaussian kernel with an asymmetric component, combining a standard Gaussian an
 
 ```cpp
 AsymmetricGaussKernelParameters{
-    double width                                           = 3.0,
-    double amplitude                                       = 3.0,
-    double amplitudeGlobal                                 = 0.0,
-    double timeShift                                       = 0.0,
-    bool   circular                                        = true,
-    bool   normalized                                      = true,
-    std::optional<ElementDimensions> outputFieldDimensions = std::nullopt
+    double width           = 3.0,
+    double amplitude       = 3.0,
+    double amplitudeGlobal = 0.0,
+    double timeShift       = 0.0,
+    bool   circular        = true,
+    bool   normalized      = true
 }
 ```
 
@@ -213,7 +206,6 @@ AsymmetricGaussKernelParameters{
 | `timeShift` | `0.0` | Controls the strength of the asymmetric (derivative) component — positive values bias activity toward higher positions |
 | `circular` | `true` | Boundary wrapping |
 | `normalized` | `true` | Area normalization |
-| `outputFieldDimensions` | `nullopt` | When set, the convolution output is resampled to this size — enables cross-dimension connections (see [Cross-dimension kernels](#cross-dimension-kernels)) |
 
 ### Components
 
@@ -224,40 +216,13 @@ AsymmetricGaussKernelParameters{
 
 ---
 
-## Cross-dimension kernels
+## Bridging fields of different sizes
 
-By default, a kernel's output is the same size as its input. Setting `outputFieldDimensions` in any kernel's parameters changes this: after convolution, the result is resampled to the specified size using linear interpolation. This lets a kernel act as a bridge between two neural fields that have different spatial resolutions.
-
-### When to use it
-
-- **Downsampling:** a high-resolution perceptual field (e.g., 200 positions) feeding a lower-resolution decision field (e.g., 100 positions).
-- **Upsampling:** a compact motor-command field projecting back onto a larger sensory field.
-- **Resolution mismatch:** any architecture where two fields operate at different spatial scales.
-
-### Code example
-
-```cpp
-// Field 200 → GaussKernel (in=200, out=100) → Field 100
-GaussKernelParameters gkp{ 3.0, 3.0, -0.01, true, true,
-                            ElementDimensions{ 100 } };   // output size
-
-auto fieldSrc = makeField("src", 200);
-auto kernel   = std::make_shared<GaussKernel>(ElementCommonParameters{"k", 200}, gkp);
-auto fieldDst = makeField("dst", 100);
-
-kernel->addInput(fieldSrc);    // src output (size 200) → kernel input (size 200)
-fieldDst->addInput(kernel);    // kernel output (size 100) → dst input (size 100)
-```
-
-The same `outputFieldDimensions` parameter is available on `MexicanHatKernel`, `OscillatoryKernel`, and `AsymmetricGaussKernel`.
-
-### Square mode (default)
-
-When `outputFieldDimensions` is `nullopt` (the default), the kernel output is the same size as its input — no resampling occurs. Setting `outputFieldDimensions` to a size equal to the input size is equivalent to leaving it unset.
-
-### Changing output size at runtime
-
-In the **Element Control** panel, select a kernel and edit the **Output Size** and **Output Step** fields. Committing the value (Enter or focus-loss) rebuilds the kernel and severs any existing connections, since the element graph's dimension contract changes. Reconnect the kernel to fields of the correct sizes afterwards.
+Kernels always produce an output the same size as their input. To connect two
+neural fields that operate at different spatial resolutions, insert a **`Resize`**
+(or **`Resize2D`**) element between them — it resamples a field of size N to a
+field of size M using linear, nearest, or cubic interpolation. See the
+[Resize](#resize) and [Resize2D](#resize2d) sections below.
 
 ---
 
@@ -609,3 +574,94 @@ field->addInput(memTrace);             // field receives the trace as input (sca
 ### Usage note
 
 `setParameters()` does **not** call `init()` — the accumulated trace is preserved when parameters are changed at runtime. Call `init()` explicitly if you want to reset the trace to zero.
+
+---
+
+## Resize
+
+A standalone resampling element. It takes an input field of spatial size **N** and produces an output of a user-specified size **M** via interpolation, acting as a bridge between two neural fields of different spatial resolutions. `Resize` performs **only** resampling — no kernel is applied — so it is the way to connect fields of different sizes.
+
+**Label:** `RESIZE`
+
+### Parameters
+
+```cpp
+ResizeParameters{
+    InterpolationMethod method          = InterpolationMethod::LINEAR,
+    ElementDimensions   inputDimensions = ElementDimensions{}   // dimensions of the source field
+}
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `method` | `LINEAR` | Interpolation method used for resampling |
+| `inputDimensions` | `{100, 1.0}` | Spatial dimensions of the source field (drives the input buffer size); auto-updated when an input is connected via `addInput()` |
+
+The **output** size is the element's own `ElementCommonParameters` dimensions (size M); the **input** size is `inputDimensions` (size N).
+
+### Interpolation methods
+
+| Method | Enum | Description |
+|---|---|---|
+| Linear | `InterpolationMethod::LINEAR` | Piecewise linear interpolation |
+| Nearest | `InterpolationMethod::NEAREST` | Nearest-neighbour sampling |
+| Cubic | `InterpolationMethod::CUBIC` | Catmull-Rom cubic spline interpolation |
+
+### Components
+
+| Name | Description |
+|---|---|
+| `"input"` | Raw input from the connected source field (size N) |
+| `"output"` | Input resampled to size M |
+
+### Connecting
+
+`addInput()` is overridden to size the `"input"` buffer to the source's output size, so the input and output sizes may legitimately differ:
+
+```cpp
+// Field (size 100) → Resize (in=100, out=50) → Field (size 50)
+auto resize = std::make_shared<element::Resize>(
+    element::ElementCommonParameters{ "resize", element::ElementDimensions{ 50, 2.0 } },
+    element::ResizeParameters{ element::InterpolationMethod::LINEAR,
+                               element::ElementDimensions{ 100, 1.0 } });
+
+resize->addInput(fieldSrc);   // src output (100) → resize input (100)
+fieldDst->addInput(resize);   // resize output (50) → dst input (50)
+```
+
+### Changing input size at runtime
+
+In the **Element Control** panel a `Resize` shows separate **Output dimensions** (Out size / Out step) and **Input dimensions** (In size / In step) sections. Editing the input size calls `changeInputDimensions()`, which rebuilds the input buffer and severs existing connections (reconnect a source of the new size afterwards). The interpolation method is editable in the parameters section.
+
+---
+
+## Resize2D
+
+2D variant of `Resize`. Resamples a 2D input field of size **Nx × Ny** to an output of size **Mx × My** using separable interpolation (each row is resampled along x, then each column along y).
+
+**Label:** `RESIZE_2D`
+
+### Parameters
+
+```cpp
+Resize2DParameters{
+    InterpolationMethod method          = InterpolationMethod::LINEAR,
+    ElementDimensions   inputDimensions = ElementDimensions{ 100, 100, 1.0, 1.0 }
+}
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `method` | `LINEAR` | Interpolation method (linear / nearest / cubic), applied separably on both axes |
+| `inputDimensions` | `{100, 100, 1.0, 1.0}` | Spatial dimensions of the source field; auto-updated when an input is connected |
+
+### Components
+
+| Name | Description |
+|---|---|
+| `"input"` | Flat `Nx * Ny` (y-major) input from the connected source field |
+| `"output"` | Input resampled to `Mx * My` |
+
+### Changing input size at runtime
+
+Like `Resize`, the **Element Control** panel exposes editable **Output dimensions** (Out x/y size & step) and **Input dimensions** (In x/y size & step) sections; committing a value calls `changeInputDimensions()` and severs existing connections.

--- a/dynamic-neural-field-composer/wiki/Elements.md
+++ b/dynamic-neural-field-composer/wiki/Elements.md
@@ -99,6 +99,10 @@ The `ElementLabel` enum identifies element types and is used by `ElementFactory`
 | `GAUSS_FIELD_COUPLING` | `"gauss field coupling"` | `GaussFieldCoupling` |
 | `BOOST_STIMULUS` | `"boost stimulus"` | `BoostStimulus` |
 | `MEMORY_TRACE` | `"memory trace"` | `MemoryTrace` |
+| `RESIZE` | `"resize"` | `Resize` |
+| `RESIZE_2D` | `"resize 2d"` | `Resize2D` |
+
+Each element above also has a 2D counterpart (e.g. `NEURAL_FIELD_2D`, `GAUSS_KERNEL_2D`).
 
 ---
 

--- a/dynamic-neural-field-composer/wiki/Examples.md
+++ b/dynamic-neural-field-composer/wiki/Examples.md
@@ -294,6 +294,33 @@ Demonstrates `GaussFieldCoupling` — a fixed (non-learnable) coupling using a G
 
 ---
 
+## Resampling examples
+
+### resize
+
+**Source:** `examples/resize.cpp`
+**Executable:** `example_resize`
+
+Demonstrates the `Resize` and `Resize2D` elements, which resample a field to a different spatial size and discretization. The example builds two parallel architectures (1D and 2D) in the same simulation, each of the form *stimulus → field u → kernel u-u → resize u-v → field v*, where field **v** has a different spatial size (and, in 1D, a different step) than field **u**.
+
+**Architecture (1D):**
+- One `GaussStimulus` (size 100, step 1.0) driving field **u**
+- `NeuralField` **u** (size 100, step 1.0) with a self-coupling `GaussKernel`
+- `Resize` **u-v** resampling u's output (100) to v's size (50, step 2.0) via linear interpolation
+- `NeuralField` **v** (size 50, step 2.0) — different size *and* discretization than u
+- Line plots of u's and v's `activation` (separate plots)
+
+**Architecture (2D):**
+- One `GaussStimulus2D` (50×50) driving field **u**
+- `NeuralField2D` **u** (50×50) with a self-coupling `GaussKernel2D`
+- `Resize2D` **u-v** resampling u's output (50×50) to v's size (80×80)
+- `NeuralField2D` **v** (80×80) — different spatial size than u
+- Heatmaps of u's and v's `activation` (separate plots)
+
+**Key concepts:** spatial resampling, `Resize` / `Resize2D`, heterogeneous field sizes and discretizations, interpolation methods (linear / nearest / cubic), bridging fields of different resolutions
+
+---
+
 ## Common pattern
 
 Every example follows the same seven-step skeleton. Two construction styles are available for step 3.

--- a/dynamic-neural-field-composer/wiki/How to Add New Elements.md
+++ b/dynamic-neural-field-composer/wiki/How to Add New Elements.md
@@ -507,6 +507,7 @@ Copy this checklist into the PR description for each new element:
 - [ ] CMakeLists.txt: source file added
 - [ ] include/dynamic-neural-field-composer.h: include added
 - [ ] tests/elements/test_your_element.cpp + registered in tests/CMakeLists.txt
-- [ ] examples/ex_your_element.cpp + registered in examples/CMakeLists.txt
-- [ ] README.md elements table updated
+- [ ] examples/your_element.cpp + registered in examples/CMakeLists.txt
+- [ ] main README.md Elements section
+- [ ] wiki folder update all pages related with element suite (Element-Reference.md, Elements.md, Examples.md)
 ```


### PR DESCRIPTION
## What and why

Closes #33 

Adds standalone `Resize` (1D) and `Resize2D` elements that resample an input
field of size N to a user-specified size M via linear / nearest / cubic
interpolation, bridging neural fields of different spatial resolutions.

- New elements + factory/UI/NodeGraph wiring
- Editable input & output dimensions in the Element control window
- Unit tests, combined 1D+2D example
- Removed the deprecated kernel `outputFieldDimensions` cross-dimension feature
  (superseded by these elements) from docs and the leftover comment

## Checklist

- [x] Tests added or updated
- [x] Doxygen updated (if public API changed)
- [x] Wiki updated (if user-visible behaviour changed)
- [x] CI passes (Windows, Linux, macOS)
