### PR TITLE
Refactor legacy toString methods to use modern to use modern std::format

### DIFF
--- a/dynamic-neural-field-composer/src/element_parameters/gauss_kernel_parameters.cpp
+++ b/dynamic-neural-field-composer/src/element_parameters/gauss_kernel_parameters.cpp
@@ -1,4 +1,5 @@
 ﻿#include "element_parameters/gauss_kernel_parameters.h"
+#include <format>
 
 namespace dnf_composer
 {
@@ -21,12 +22,13 @@ namespace dnf_composer
 
 		std::string GaussKernelParameters::toString() const override
 		{
-			std::string result = "Gauss kernel parameters\n";
-			result += "Width: " + std::to_string(width) + "\n";
-			result += "Amplitude: " + std::to_string(amplitude) + "\n";
-			result += "Circular: " + std::to_string(circular) + "\n";
-			result += "Normalized: " + std::to_string(normalized) + "\n";
-			return result;
+			return std::format(
+        "Gauss kernel parameters\n"
+        "Width: {:.2f}\n"
+        "Amplitude: {:.2f}\n"
+        "Circular: {}\n"
+        "Normalized: {}\n",
+        width, amplitude, circular, normalized);
 		}
 	}
 }

--- a/dynamic-neural-field-composer/src/element_parameters/gauss_stimulus_parameters.cpp
+++ b/dynamic-neural-field-composer/src/element_parameters/gauss_stimulus_parameters.cpp
@@ -1,4 +1,5 @@
 ﻿#include "element_parameters/gauss_stimulus_parameters.h"
+#include <format>
 
 namespace dnf_composer
 {
@@ -25,13 +26,11 @@ namespace dnf_composer
 
 		std::string GaussStimulusParameters::toString() const override
 		{
-			std::string result = "Gaussian stimulus parameters\n";
-			result += "Width = " + std::to_string(width) + ", ";
-			result += "Amplitude = " + std::to_string(amplitude) + ", ";
-			result += "Position = " + std::to_string(position) + ", ";
-			result += "Circular = " + std::to_string(circular) + ", ";
-			result += "Normalized = " + std::to_string(normalized) + ", ";
-			return result;
+			return std::format(
+        "Gaussian stimulus parameters\n"
+        "Width = {:.2f}, Amplitude = {:.2f}, Position = {:.2f}, "
+        "Circular = {}, Normalized = {}, ",
+        width, amplitude, position, circular, normalized);
 		}
 	}
 }

--- a/dynamic-neural-field-composer/src/element_parameters/mexican_hat_kernel_parameters.cpp
+++ b/dynamic-neural-field-composer/src/element_parameters/mexican_hat_kernel_parameters.cpp
@@ -1,4 +1,5 @@
 ﻿#include "element_parameters/mexican_hat_kernel_parameters.h"
+#include <format>
 
 namespace dnf_composer
 {
@@ -24,14 +25,15 @@ namespace dnf_composer
 
 		std::string MexicanHatKernelParameters::toString() const
 		{
-			std::string result = "Mexican-hat kernel parameters\n";
-			result += "Width exc: " + std::to_string(widthExc) + "\n";
-			result += "Amplitude exc: " + std::to_string(amplitudeExc) + "\n";
-			result += "Width inh: " + std::to_string(widthInh) + "\n";
-			result += "Amplitude inh: " + std::to_string(amplitudeInh) + "\n";
-			result += "Circular: " + std::to_string(circular) + "\n";
-			result += "Normalized: " + std::to_string(normalized) + "\n";
-			return result;
+			return std::format(
+        "Mexican-hat kernel parameters\n"
+        "Width Exc: {:.2f}\n"
+        "Amplitude Exc: {:.2f}\n"
+        "Width Inh: {:.2f}\n"
+        "Amplitude Inh: {:.2f}\n"
+        "Circular: {}\n"
+        "Normalized: {}\n",
+        widthExc, amplitudeExc, widthInh, amplitudeInh, circular, normalized);
 		}
 	}
 }

--- a/dynamic-neural-field-composer/src/element_parameters/neural_field_parameters.cpp
+++ b/dynamic-neural-field-composer/src/element_parameters/neural_field_parameters.cpp
@@ -1,4 +1,5 @@
 ﻿#include "element_parameters/neural_field_parameters.h"
+#include <format>
 
 namespace dnf_composer
 {
@@ -47,10 +48,12 @@ namespace dnf_composer
 
 		std::string NeuralFieldParameters::toString() const
 		{
-			std::string result = "Neural field parameters\n";
-			result += "Tau: " + std::to_string(tau) + "\n";
-			result += "Resting level: " + std::to_string(startingRestingLevel) + "\n";
-			result += "Activation function: " + activationFunction->toString() + "\n";
+			return std::format(
+        "Neural field parameters\n"
+        "Tau: {:.2f}\n"
+        "Resting level: {:.2f}\n"
+        "Activation function: {}\n",
+        tau, startingRestingLevel, activationFunction->toString());
 			return result;
 		}
 
@@ -72,12 +75,14 @@ namespace dnf_composer
 
 		std::string NeuralFieldBump::toString() const
 		{
-			std::string str = "Bump\n";
-			str += "Centroid: " + std::to_string(centroid) + "\n";
-			str += "Amplitude: " + std::to_string(amplitude) + "\n";
-			str += "Start position: " + std::to_string(startPosition) + "\n";
-			str += "End position: " + std::to_string(endPosition) + "\n";
-			str += "Width: " + std::to_string(width) + "\n";
+			return std::format(
+        "Bump\n"
+        "Centroid: {:.2f}\n"
+        "Amplitude: {:.2f}\n"
+        "Start position: {:.2f}\n"
+        "End position: {:.2f}\n"
+        "Width: {:.2f}\n",
+        centroid, amplitude, startPosition, endPosition, width);
 			return str;
 		}
 
@@ -95,14 +100,17 @@ namespace dnf_composer
 
 		std::string NeuralFieldState::toString() const
 		{
-			std::string str = "Neural field state\n";
-			str += "Stable: " + std::to_string(stable) + "\n";
-			str += "Lowest activation: " + std::to_string(lowestActivation) + "\n";
-			str += "Highest activation: " + std::to_string(highestActivation) + "\n";
-			str += "Threshold for stability: " + std::to_string(thresholdForStability) + "\n";
-			str += "Bumps:\n";
-			for (const auto& bump : bumps)
-				str += bump.toString();
+			std::string str = std::format(
+				"Neural field state\n"
+				"Stable: {}\n"
+				"Lowest activation: {:.2f}\n"
+				"Highest activation: {:.2f}\n"
+				"Threshold for stability: {:.2f}\n"
+				"Bumps:\n",
+				stable, lowestActivation, highestActivation, thresholdForStability);
+		    for (const auto& bump : bumps)
+			str += bump.toString();
+			
 			return str;
 		}
 

--- a/dynamic-neural-field-composer/src/visualization/plot_parameters.cpp
+++ b/dynamic-neural-field-composer/src/visualization/plot_parameters.cpp
@@ -1,5 +1,5 @@
 #include "visualization/plot_parameters.h"
-
+#include <format> 
 
 namespace dnf_composer
 {
@@ -57,15 +57,10 @@ namespace dnf_composer
 
 	std::string PlotDimensions::toString() const
 	{
-		std::string result;
-		result += "Plot dimensions: {";
-		result += "xMin: " + std::to_string(xMin) + ", ";
-		result += "xMax: " + std::to_string(xMax) + ", ";
-		result += "yMin: " + std::to_string(yMin) + ", ";
-		result += "yMax: " + std::to_string(yMax) + ", ";
-		result += "xStep: " + std::to_string(xStep) + ", ";
-		result += "yStep: " + std::to_string(yStep) + "}";
-		return result;
+		return std::format(
+        "Plot dimensions: {{xMin: {:.2f}, xMax: {:.2f}, "
+        "yMin: {:.2f}, yMax: {:.2f}, xStep: {:.2f}, yStep: {:.2f}}}",
+        xMin, xMax, yMin, yMax, xStep, yStep);
 	}
 
 	bool PlotDimensions::operator==(const PlotDimensions& other) const
@@ -90,12 +85,9 @@ namespace dnf_composer
 
 	std::string PlotAnnotations::toString() const
 	{
-		std::string result;
-		result += "Plot annotations: {";
-		result += "title: " + title + ", ";
-		result += "x_label: " + x_label + ", ";
-		result += "y_label: " + y_label + "}";
-		return result;
+		return std::format(
+        "Plot annotations: {{title: {}, x_label: {}, y_label: {}}}",
+        title, x_label, y_label);
 	}
 
 	bool PlotAnnotations::operator==(const PlotAnnotations& other) const
@@ -121,13 +113,11 @@ namespace dnf_composer
 
 	std::string PlotCommonParameters::toString() const
 	{
-		std::string result;
-		result += "Plot parameters: [ ";
-		result += "type: " + PlotTypeToString.at(type) + ", ";
-		result += dimensions.toString() + ", ";
-		result += annotations.toString() + " ]";
-		return result;
+		return std::format(
+			"Plot parameters: [ type: {}, {}, {} ]",
+			PlotTypeToString.at(type), dimensions.toString(), annotations.toString());
 	}
+	
 
 	bool PlotCommonParameters::operator==(const PlotCommonParameters& other) const
 	{


### PR DESCRIPTION
Hi @Jgocunha,

I have refactored the legacy 'toString()' string builders across the parameter and visualization classes to utilize modern C++20 'std::format', as requested in the issue.

**Summary of changes:**
* Added `#include <format>` across all 5 target files.
* Updated `double` parameters to use `{:.2f}` to control float precision cleanly.
* Utilized escape braces `{{ }}` to correctly handle literal braces inside formatting strings for plot layout configurations.

Closes #62