### PR TITLE
fix: reject duplicate element names when loading a .dnf file

### DIFF
--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -1,5 +1,7 @@
 #include "simulation/simulation_file_manager.h"
 
+#include <unordered_set>
+
 
 namespace dnf_composer
 {
@@ -529,11 +531,25 @@ namespace dnf_composer
 
     void SimulationFileManager::jsonToElements(const json& jsonElements) const
     {
+        // Track names already loaded so duplicate uniqueNames in the file are rejected
+        // (mirrors the guard in Simulation::addElement). Used by both passes below.
+        std::unordered_set<std::string> seenNames;
+
          //Iterate over elements in the JSON and reconstruct them
-	    for (const auto& elementJson : jsonElements) 
+	    for (const auto& elementJson : jsonElements)
         {
 	        // Parse common parameters
 	        const std::string uniqueName = elementJson["uniqueName"];
+
+	        // Reject duplicate element names: keep the first occurrence, skip the rest
+	        // (and their interactions in the second pass) with a clear error.
+	        if (!seenNames.insert(uniqueName).second)
+	        {
+	            log(tools::logger::LogLevel::ERROR, "Duplicate element name '" + uniqueName
+	                + "' in file - skipping this element.");
+	            continue;
+	        }
+
 	        const std::string labelStr = elementJson["label"][1].get<std::string>();
 	        const element::ElementLabel elementLabel = elementLabelFromString(labelStr);
 	        const int x_max = elementJson["x_max"];
@@ -1015,9 +1031,17 @@ namespace dnf_composer
     }
 
 	    // Iterate to create interactions
+	    std::unordered_set<std::string> wiredNames;
 	    for (const auto& elementJson : jsonElements)
 	    {
 	        const std::string uniqueName = elementJson["uniqueName"];
+
+	        // Skip the interactions of a duplicate entry: only the first occurrence of a
+	        // name was loaded, so wiring a later duplicate's inputs would attach them to
+	        // the wrong (first) element.
+	        if (!wiredNames.insert(uniqueName).second)
+	            continue;
+
 	        const auto& inputsJson = elementJson["inputs"];
 
             if(!inputsJson.empty())

--- a/dynamic-neural-field-composer/tests/simulation/test_simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_simulation_file_manager.cpp
@@ -1377,3 +1377,57 @@ TEST_F(SimulationFileManagerTest, RoundTripAllDimensionBridgingElements)
     EXPECT_NE(simB->getElement("cl 1"),   nullptr);
     EXPECT_NE(simB->getElement("ex 1"),   nullptr);
 }
+
+// ---------------------------------------------------------------------------
+// Duplicate element names (issue #44)
+// ---------------------------------------------------------------------------
+
+TEST_F(SimulationFileManagerTest, LoadRejectsDuplicateElementNames)
+{
+    // A .dnf with two elements named "nf 1". Only the first must be kept; the
+    // duplicate (and its interactions) must be skipped, so downstream name
+    // lookups stay unambiguous. "gk 1" is wired to "nf 1"; the duplicate "nf 1"
+    // declares a bogus input that must NOT be wired onto the kept element.
+    const std::string dir = tempDir + "dup-names/";
+    fs::create_directories(dir);
+    const std::string path = dir + "dup-names.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "dup-names",
+            "deltaT": 1.0,
+            "elements": [
+                { "uniqueName": "nf 1", "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "activationFunction": { "type": "sigmoid", "x_shift": 0.0, "steepness": 10.0 },
+                  "inputs": [] },
+                { "uniqueName": "nf 1", "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "activationFunction": { "type": "sigmoid", "x_shift": 0.0, "steepness": 10.0 },
+                  "inputs": [["gk 1", "output"]] },
+                { "uniqueName": "gk 1", "label": [3, "gauss kernel"],
+                  "x_max": 100, "d_x": 1.0, "amplitude": 10.0, "width": 5.0,
+                  "circular": true, "normalized": true, "amplitudeGlobal": 0.0,
+                  "inputs": [["nf 1", "output"]] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("dup-names-load", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    ASSERT_NO_THROW(sfm.loadElementsFromJson());
+
+    // Exactly two elements survive: one "nf 1" and one "gk 1" (the duplicate is dropped).
+    EXPECT_EQ(sim->getNumberOfElements(), 2);
+    EXPECT_NE(sim->getElement("nf 1"), nullptr);
+    EXPECT_NE(sim->getElement("gk 1"), nullptr);
+
+    // The kept "nf 1" is wired to feed "gk 1" (first element's interactions are honoured).
+    const auto consumersOfNf = sim->getElementsThatHaveSpecifiedElementAsInput("nf 1");
+    ASSERT_FALSE(consumersOfNf.empty());
+    EXPECT_EQ(consumersOfNf.front()->getUniqueName(), "gk 1");
+
+    // The duplicate's bogus interaction (gk 1 -> nf 1) must NOT have been wired onto
+    // the kept "nf 1": the kept field has no inputs.
+    EXPECT_TRUE(sim->getElement("nf 1")->getInputs().empty());
+}


### PR DESCRIPTION
## Summary

Closes #44   duplicate element names in a `.dnf` file are now rejected during load.

A `.dnf` containing two elements with the same `uniqueName` was deserialised without a load-level collision check. `Simulation::addElement` already skipped the duplicate at runtime, so it wasn't double-registered — **but** the interaction pass still processed the dropped duplicate's JSON entry. Because `getElement(name)` returns the *first* match, the duplicate's input edges were silently wired onto the kept element, corrupting the loaded graph. Downstream name lookups (`getElement`, interactions, plotting) then became ambiguous.

## Changes

`SimulationFileManager::jsonToElements`:
- **Element loop:** tracks seen `uniqueName`s and skips later duplicates, logging a clear `ERROR` (`"Duplicate element name '<name>' in file - skipping this element."`) *before* the element is constructed/added.
- **Interaction loop:** skips the interactions of duplicate entries so their edges can't be mis-attached to the first occurrence.

The first occurrence is kept and the rest of the file still loads — matching the lenient, log-and-continue behavior of `Simulation::addElement` (left in place as the runtime backstop).

## Tests

Added `LoadRejectsDuplicateElementNames`: loads a `.dnf` with two `nf 1` entries (the duplicate carrying a bogus `gk 1 → nf 1` edge) plus a `gk 1` wired from `nf 1`, and asserts:
- exactly 2 elements survive (one `nf 1`, one `gk 1`),
- `gk 1` is wired to the kept `nf 1`,
- the kept `nf 1` has no inputs (the duplicate's interaction was not mis-wired).

Existing file-manager round-trip tests are unaffected.

## Notes

Behavior is **skip-with-error** (load the rest), not fail-the-whole-load.
