### PR TITLE
ci: add free AI automation workflows and CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,58 @@
+language: en-US
+
+reviews:
+  # Review all PRs automatically, including from first-time contributors
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Project-specific review instructions
+  instructions: |
+    This is **dynamic-neural-field-composer**, a C++20 library and GUI application implementing
+    Dynamic Neural Fields. The GUI uses Dear ImGui with the imgui-platform-kit layer.
+    vcpkg packages: imgui (docking-experimental, glfw/opengl3 bindings), implot,
+    imgui-node-editor, nlohmann-json, gtest, catch2.
+
+    Review every PR for the following, posting inline comments on the relevant lines:
+
+    **Code style (CONTRIBUTING.md / Clean Code)**
+    - Meaningful names: variables, functions, and types should read like prose.
+    - No raw owning pointers — std::shared_ptr / std::unique_ptr only.
+    - Small focused functions with a single responsibility.
+    - No comments that explain *what*; only add one if the *why* is non-obvious.
+    - C++20 idioms preferred (ranges, concepts, structured bindings, std::span, etc.).
+
+    **Test coverage**
+    - Changes to element behaviour, simulation logic, or utilities must have tests in
+      `dynamic-neural-field-composer/tests/` (Google Test target `dnf_composer_tests` or Catch2).
+    - Flag any new public functions or changed behaviour without corresponding tests.
+
+    **Doxygen documentation**
+    - All new or changed public functions/classes/structs under `include/` need Doxygen
+      blocks with at minimum `@brief`, one `@param` per parameter, and `@return` (unless void).
+    - Flag missing or stale Doxygen.
+
+    **Performance and safety**
+    - Unnecessary copies of heavy objects (field matrices, kernel vectors).
+    - Prefer std::string_view / std::span over const-ref where applicable.
+    - std::shared_ptr inside hot simulation loops (prefer value types or unique_ptr for
+      objects that do not need sharing).
+
+    **External contributors (FIRST_TIME_CONTRIBUTOR or no prior contributions):**
+    Open your review comment with a short, welcoming paragraph that thanks the author,
+    links to CONTRIBUTING.md, and notes that a maintainer will do a final review once CI
+    is green. Keep the overall tone encouraging and constructive.
+
+  # Files to exclude from review
+  path_filters:
+    - "!build/**"
+    - "!dynamic-neural-field-composer/docs/**"
+    - "!vcpkg/**"
+    - "!deps/**"
+    - "!**/compile_commands.json"
+    - "!**/*.json.in"
+    - "!CMakeCache.txt"
+    - "!**/CMakeFiles/**"
+
+chat:
+  auto_reply: true

--- a/.github/workflows/gemini-doc-sync.yml
+++ b/.github/workflows/gemini-doc-sync.yml
@@ -1,0 +1,86 @@
+name: Documentation Sync Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+    paths:
+      - 'dynamic-neural-field-composer/include/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  doc-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check documentation completeness with Gemini
+        uses: google-github-actions/run-gemini-cli@v0
+        with:
+          version: latest
+          prompt: |
+            This pull request modifies one or more public API headers under
+            `dynamic-neural-field-composer/include/`. Audit the documentation impact and post a
+            single PR comment listing what needs updating. Do NOT commit or modify any files.
+
+            Repository: ${{ github.repository }}
+            PR number: ${{ github.event.pull_request.number }}
+
+            Project layout:
+            - Public headers: dynamic-neural-field-composer/include/**/*.h
+            - Wiki pages:     dynamic-neural-field-composer/wiki/*.md
+            - README:         README.md (top-level)
+            - Changelog:      CHANGELOG.md (top-level)
+
+            Doxygen convention (CONTRIBUTING.md): every public function, class, and struct in
+            include/ must have a Doxygen block with at minimum @brief, one @param per parameter,
+            and @return (unless void).
+
+            Steps:
+            1. Run: gh pr diff ${{ github.event.pull_request.number }}
+               to see the changed files and lines.
+
+            2. For each changed header file, check:
+
+               a) Doxygen — new public functions/methods: does each have a complete block?
+                  Existing functions with changed signatures: is the Doxygen still accurate?
+                  List each issue as: include/path/file.h — FunctionName: what is missing.
+
+               b) Wiki — read relevant pages in dynamic-neural-field-composer/wiki/ that cover
+                  the changed elements. Identify sections referencing the changed API that may
+                  now be stale. List each as: wiki/PageName.md — section "Heading": description.
+
+               c) README — scan README.md for code snippets using the changed API. List any
+                  snippets that may need updating with an approximate line reference.
+
+               d) CHANGELOG — if the API change is notable (new feature, behaviour change,
+                  parameter rename), flag that CHANGELOG.md may need an entry under [Unreleased].
+
+            3. Post the findings as a PR comment:
+               gh pr comment ${{ github.event.pull_request.number }} --body "..."
+
+               Use this structure in the comment body:
+               ## Documentation sync check
+
+               ### Doxygen
+               - [ ] include/path/file.h — FunctionName: missing @param x
+
+               ### Wiki
+               - [ ] wiki/Elements.md — section "Kernel Parameters": update for sigma rename
+
+               ### README
+               - [ ] Line ~42: snippet uses old constructor signature
+
+               ### CHANGELOG
+               - [ ] Consider adding entry under [Unreleased] for the ElementFactory API change
+
+               Write "No issues found." under any heading with nothing to report.
+               One line per item. Do not suggest replacement wording — only identify what needs attention.
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gemini-issue-triage.yml
+++ b/.github/workflows/gemini-issue-triage.yml
@@ -1,0 +1,82 @@
+name: Gemini Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triage issue with Gemini
+        uses: google-github-actions/run-gemini-cli@v0
+        with:
+          version: latest
+          prompt: |
+            A new issue has been opened on **dynamic-neural-field-composer**.
+
+            Issue number: ${{ github.event.issue.number }}
+            Title: ${{ github.event.issue.title }}
+            Body:
+            ${{ github.event.issue.body }}
+            Author: @${{ github.event.issue.user.login }}
+            Repository: ${{ github.repository }}
+
+            **Step 1 — Create labels idempotently (--force is a no-op if they already exist).
+            Run each gh command:**
+            gh label create "question"           --color "#d876e3" --description "Further information is requested" --force
+            gh label create "documentation"      --color "#0075ca" --description "Improvements or additions to documentation" --force
+            gh label create "duplicate"          --color "#cfd3d7" --description "This issue or pull request already exists" --force
+            gh label create "help wanted"        --color "#008672" --description "Extra attention is needed" --force
+            gh label create "good first issue"   --color "#7057ff" --description "Good for newcomers" --force
+            gh label create "wontfix"            --color "#ffffff" --description "This will not be worked on" --force
+            gh label create "maintenance"        --color "#ededed" --description "Routine maintenance tasks" --force
+            gh label create "priority: critical" --color "#b60205" --description "Must fix immediately" --force
+            gh label create "priority: high"     --color "#e4604e" --description "Fix in the next release" --force
+            gh label create "priority: medium"   --color "#e99695" --description "Fix when possible" --force
+            gh label create "priority: low"      --color "#f9d0c4" --description "Nice to have" --force
+
+            **Step 2 — Classify the issue:**
+
+            Type label (pick exactly one):
+            - `bug`           — something is broken or behaves incorrectly.
+            - `enhancement`   — new feature or capability request.
+            - `question`      — the author is asking how to use the library.
+            - `documentation` — the docs, wiki, or Doxygen are missing or wrong.
+            - `wontfix`       — clearly out of scope or will not be addressed.
+
+            Secondary labels (add any that apply):
+            - `help wanted`      — valid but complex enough to need community help.
+            - `good first issue` — small and well-scoped (e.g. Doxygen block, typo, simple test).
+            - `duplicate`        — see Step 3.
+
+            Priority label (pick exactly one):
+            - `priority: critical` — crash, data loss, or broken build on a supported platform.
+            - `priority: high`     — significant functional regression or missing core feature.
+            - `priority: medium`   — non-blocking bug or useful enhancement.
+            - `priority: low`      — cosmetic, minor doc issue, or speculative feature.
+
+            **Step 3 — Check for duplicates:**
+            Run: gh issue list --state all --limit 100 --json number,title,state
+            Compare titles. If a clearly related open issue exists, add `duplicate` and reference
+            its number in the comment.
+
+            **Step 4 — Apply labels:**
+            gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2,..."
+
+            **Step 5 — Post a welcoming comment** (under ~150 words, not sycophantic):
+            gh issue comment ${{ github.event.issue.number }} --body "..."
+            - Thank @${{ github.event.issue.user.login }}.
+            - bug: ask to confirm OS, compiler, and version if not in the template fields.
+            - question: link to https://jgocunha.github.io/dynamic-neural-field-composer/ and wiki.
+            - enhancement: note contributions are welcome; link CONTRIBUTING.md at
+              https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md.
+            - documentation: point to wiki and Doxygen comment conventions.
+            - duplicate: explain which existing issue covers the topic; suggest continuing there.
+            - Always: note that a maintainer will follow up.
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vcpkg-maintenance.yml
+++ b/.github/workflows/vcpkg-maintenance.yml
@@ -1,0 +1,81 @@
+name: vcpkg Maintenance Check
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  vcpkg-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone vcpkg
+        run: git clone --depth=1 https://github.com/microsoft/vcpkg.git "$GITHUB_WORKSPACE/vcpkg"
+
+      - name: Build version report and create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PACKAGES="imgui implot imgui-node-editor nlohmann-json gtest catch2"
+          VCPKG_DIR="$GITHUB_WORKSPACE/vcpkg"
+          DATE=$(date +%Y-%m-%d)
+
+          # Ensure the maintenance label exists
+          gh label create maintenance \
+            --color "#ededed" \
+            --description "Routine maintenance tasks" \
+            --force 2>/dev/null || true
+
+          # Build a Markdown table of current port versions
+          TABLE="| Package | Version | Port-version | Notes |\n|---|---|---|---|\n"
+
+          for pkg in $PACKAGES; do
+            PORT_JSON="$VCPKG_DIR/ports/$pkg/vcpkg.json"
+            if [ ! -f "$PORT_JSON" ]; then
+              TABLE="${TABLE}| \`$pkg\` | not found | — | Port directory missing in cloned vcpkg |\n"
+              continue
+            fi
+
+            # Extract version (try version-semver, version-date, version in that order)
+            VERSION=$(jq -r '
+              if .["version-semver"] then .["version-semver"]
+              elif .["version-date"] then .["version-date"]
+              elif .version then .version
+              else "unknown"
+              end' "$PORT_JSON")
+
+            PORT_VERSION=$(jq -r '.["port-version"] // 0' "$PORT_JSON")
+
+            # Flag non-zero port-version (port patch without upstream version change)
+            NOTE=""
+            if [ "$PORT_VERSION" != "0" ] && [ "$PORT_VERSION" != "null" ]; then
+              NOTE="port patch applied (port-version: $PORT_VERSION)"
+            fi
+
+            TABLE="${TABLE}| \`$pkg\` | $VERSION | $PORT_VERSION | $NOTE |\n"
+          done
+
+          # Compose issue body
+          BODY=$(printf "## Monthly vcpkg dependency report — %s\n\n\
+          This is an automated monthly check of the vcpkg packages used by **dynamic-neural-field-composer**.\n\
+          The project does not pin a vcpkg baseline; CI always pulls the latest vcpkg HEAD.\n\
+          The versions below are what is currently available in the vcpkg registry.\n\n\
+          ### Package versions\n\n%s\n\
+          ### What to look for\n\n\
+          - **Non-zero port-version**: the port was patched without an upstream release — usually safe, but worth noting.\n\
+          - **Major version bumps**: may introduce breaking API changes. Consider running a manual integration test before the next release.\n\n\
+          ### Recommended action\n\n\
+          Review the table above. If any package shows a major version bump since the last report,\n\
+          clone the repo, update vcpkg, and run the CI build scripts locally to verify nothing is broken.\n\
+          Close this issue once reviewed.\n" "$DATE" "$(printf "$TABLE")")
+
+          gh issue create \
+            --title "chore: monthly vcpkg dependency report — $DATE" \
+            --label "maintenance" \
+            --body "$BODY"


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` to configure CodeRabbit GitHub App for automatic PR reviews and external contributor onboarding (free for public repos, no API key needed)
- Add `gemini-issue-triage.yml` — Gemini-powered workflow that classifies new issues, creates labels idempotently, checks for duplicates, and posts a welcome comment
- Add `gemini-doc-sync.yml` — Gemini-powered workflow triggered on `include/**` changes that audits Doxygen, wiki, README, and CHANGELOG coverage and posts a PR checklist
- Add `vcpkg-maintenance.yml` — pure `bash`/`jq` monthly cron that clones vcpkg, reads port manifests, and opens a GitHub issue with a package version table (no LLM required)

## Test plan

- [x] Trigger `vcpkg-maintenance.yml` via `workflow_dispatch` — verify a maintenance issue is created with a version table
- [x] Open a test issue — verify `gemini-issue-triage.yml` applies labels and posts a comment
- [ ] Open a PR touching `include/` — verify `gemini-doc-sync.yml` posts a doc checklist comment
- [x] Open a PR — verify CodeRabbit posts an inline review (requires the GitHub App to be installed first)
