### PR TITLE
Fix data races in Simulation construction and logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,18 @@ jobs:
   sanitizers-linux:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          - name: asan-ubsan
+            build_dir: build/linux-asan
+            cxx_flags: "-fsanitize=address,undefined -fno-omit-frame-pointer -g"
+            linker_flags: "-fsanitize=address,undefined"
+          - name: tsan
+            build_dir: build/linux-tsan
+            cxx_flags: "-fsanitize=thread -fno-omit-frame-pointer -g"
+            linker_flags: "-fsanitize=thread"
+
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       VCPKG_DEFAULT_TRIPLET: x64-linux
@@ -178,25 +190,26 @@ jobs:
           chmod +x scripts/setup.sh
           ./scripts/setup.sh
 
-      - name: Configure CMake (ASan + UBSan)
+      - name: Configure CMake (${{ matrix.name }})
         working-directory: ./dynamic-neural-field-composer
         run: |
-          cmake -S . -B build/linux-asan \
+          cmake -S . -B ${{ matrix.build_dir }} \
                 -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dynamic-neural-field-composer/deps/ipk-install \
                 -DCMAKE_CXX_COMPILER=g++-13 \
                 -DCMAKE_C_COMPILER=gcc-13 \
-                -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
-                -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+                -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
+                -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.linker_flags }}"
 
-      - name: Build (ASan + UBSan)
+      - name: Build (${{ matrix.name }})
         working-directory: ./dynamic-neural-field-composer
-        run: cmake --build build/linux-asan --parallel $(nproc)
+        run: cmake --build ${{ matrix.build_dir }} --parallel $(nproc)
 
       # ── Tests ──────────────────────────────────────────────────────────────
       - name: Run tests (ASan + UBSan)
-        working-directory: ./dynamic-neural-field-composer/build/linux-asan
+        if: matrix.name == 'asan-ubsan'
+        working-directory: ./dynamic-neural-field-composer/${{ matrix.build_dir }}
         env:
           # detect_leaks=0: connected elements hold shared_ptr to each other in
           # both directions (Element::inputs/outputs), a known ownership cycle
@@ -204,6 +217,13 @@ jobs:
           # the input-cache/ownership redesign breaks the cycle.
           ASAN_OPTIONS: halt_on_error=1:detect_leaks=0
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --output-on-failure --parallel $(nproc)
+
+      - name: Run tests (TSan)
+        if: matrix.name == 'tsan'
+        working-directory: ./dynamic-neural-field-composer/${{ matrix.build_dir }}
+        env:
+          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
         run: ctest --output-on-failure --parallel $(nproc)
 
   build-and-test-windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed two data races (reported by the downstream `neat-dnfs` TSan CI job, see
+  `.claude/reports/dnf_composer-tsan-data-races.md`) that surfaced under any concurrent use of
+  `Simulation`, e.g. evaluating multiple simulations in parallel via `std::async`:
+  - `Simulation::generateUniqueIdentifier()` and `SimulationRecorder`'s internal timestamp
+    helper used `std::localtime`, which returns a pointer to shared static storage; both now use
+    the existing reentrant `tools::utils::safe_localtime()` helper
+  - `tools::utils::getResourceRoot()`'s function-local `static const` initialization is now
+    guarded by an explicit `std::call_once` instead of relying solely on compiler-provided
+    thread-safe statics
+- Fixed a third, previously-unreported data race found while writing the regression test above:
+  `LogWindow::addLog()`/`renderContent()`/`clean()` mutated and iterated the shared static `logs`
+  vector with no locking, and `Logger::log()` reassigned a shared static `Logger` instance —
+  since every `Simulation` construction logs a message, concurrent construction reliably
+  corrupted the heap. `logs` access is now guarded by a mutex, and `Logger::log()` no longer
+  mutates shared state (the unused shared `Logger` instance was removed)
+
 ### CI
+- Added a `tsan` leg to the `sanitizers-linux` job (in addition to the existing ASan+UBSan leg)
+  to catch data races in CI
 - Added CodeRabbit configuration (`.coderabbit.yaml`) for automatic PR code review and
   external contributor onboarding (free for public repositories, no API key required)
 - Added `gemini-issue-triage.yml` workflow: classifies new issues, creates labels

--- a/dynamic-neural-field-composer/include/tools/logger.h
+++ b/dynamic-neural-field-composer/include/tools/logger.h
@@ -52,8 +52,6 @@ namespace dnf_composer::tools::logger
 	};
 
 	void log(LogLevel level, const std::string& message, LogOutputMode mode = ALL);
-
-	static Logger logger(LogLevel::INFO);
 }
 
 

--- a/dynamic-neural-field-composer/include/user_interface/log_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/log_window.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <cstdarg>
+#include <mutex>
 #include <imgui-platform-kit/user_interface_window.h>
 
 #include "application/application.h"
@@ -23,6 +24,7 @@ namespace dnf_composer::user_interface
 	{
     private:
         inline static std::vector<LogEntry> logs;
+        inline static std::mutex logsMutex;
         inline static ImGuiTextFilter filter;
         inline static bool autoScroll = true;
         inline static bool isWindowActive = false;
@@ -37,7 +39,7 @@ namespace dnf_composer::user_interface
         static void setExpanded(bool v)   { s_expanded = v; }
         ~LogWindow() override = default;
     private:
-        static void clean() { logs.clear(); }
+        static void clean() { std::lock_guard lock(logsMutex); logs.clear(); }
         static void draw();
         static void renderContent();
     };

--- a/dynamic-neural-field-composer/src/simulation/simulation.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation.cpp
@@ -556,8 +556,11 @@ namespace dnf_composer
 		const auto now = std::chrono::system_clock::now();
 		const auto time_t = std::chrono::system_clock::to_time_t(now);
 
+		std::tm tm{};
+		tools::utils::safe_localtime(&time_t, &tm);
+
 		std::ostringstream oss;
-		oss << std::put_time(std::localtime(&time_t), "default sim [%Y-%m-%d] [%H-%M-%S]");
+		oss << std::put_time(&tm, "default sim [%Y-%m-%d] [%H-%M-%S]");
 		uniqueIdentifier = oss.str();
 	}
 

--- a/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
@@ -21,8 +21,11 @@ namespace dnf_composer
 			const auto t    = std::chrono::system_clock::to_time_t(now);
 			const auto ms   = std::chrono::duration_cast<std::chrono::milliseconds>(
 			                      now.time_since_epoch()) % 1000;
+			std::tm tm{};
+			tools::utils::safe_localtime(&t, &tm);
+
 			std::ostringstream oss;
-			oss << std::put_time(std::localtime(&t), "%Y-%m-%d_%H-%M-%S")
+			oss << std::put_time(&tm, "%Y-%m-%d_%H-%M-%S")
 			    << "_" << std::setfill('0') << std::setw(3) << ms.count();
 			return oss.str();
 		}

--- a/dynamic-neural-field-composer/src/tools/logger.cpp
+++ b/dynamic-neural-field-composer/src/tools/logger.cpp
@@ -85,8 +85,7 @@ namespace dnf_composer::tools::logger
 }
 #endif
 
-        logger = Logger(level, mode);
-        logger.log(message);
+        Logger(level, mode).log(message);
     }
 
     std::string Logger::getLogLevelColorCodeCmd(const LogLevel level)

--- a/dynamic-neural-field-composer/src/tools/utils.cpp
+++ b/dynamic-neural-field-composer/src/tools/utils.cpp
@@ -1,6 +1,7 @@
 ﻿#include "tools/utils.h"
 
 #include <array>
+#include <mutex>
 
 #ifdef _WIN32
 #  include <windows.h>
@@ -16,9 +17,12 @@
 
 namespace dnf_composer::tools::utils
 {
-	std::string getResourceRoot()
+	namespace
 	{
-		static const std::string cached = []() -> std::string
+		std::once_flag resourceRootOnce;
+		std::string resourceRootCache;
+
+		std::string computeResourceRoot()
 		{
 			std::filesystem::path exeDir;
 #ifdef _WIN32
@@ -52,8 +56,13 @@ namespace dnf_composer::tools::utils
 				return parent.string();
 }
 			return {PROJECT_DIR};
-		}();
-		return cached;
+		}
+	}
+
+	std::string getResourceRoot()
+	{
+		std::call_once(resourceRootOnce, [] { resourceRootCache = computeResourceRoot(); });
+		return resourceRootCache;
 	}
 
 	int countNumOfLinesInFile(const std::string& filename)

--- a/dynamic-neural-field-composer/src/user_interface/log_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/log_window.cpp
@@ -40,13 +40,16 @@ namespace dnf_composer::user_interface
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
 			ImGui::PushFont(g_MonoMediumFont);
 			ImGui::PushTextWrapPos(0.0F);
-			for (const auto& [message, color] : logs)
 			{
-				if (filter.PassFilter(message.c_str()))
+				std::lock_guard lock(logsMutex);
+				for (const auto& [message, color] : logs)
 				{
-					ImGui::PushStyleColor(ImGuiCol_Text, color);
-					ImGui::TextEx(message.c_str());
-					ImGui::PopStyleColor();
+					if (filter.PassFilter(message.c_str()))
+					{
+						ImGui::PushStyleColor(ImGuiCol_Text, color);
+						ImGui::TextEx(message.c_str());
+						ImGui::PopStyleColor();
+					}
 				}
 			}
 			ImGui::PopTextWrapPos();
@@ -70,6 +73,7 @@ namespace dnf_composer::user_interface
 		vsnprintf(buffer.data(), buffer.size(), fmt, args);
 		buffer.back() = '\0';
 		 va_end(args);
+		std::lock_guard lock(logsMutex);
 		logs.push_back({ buffer.data(), color });
 	}
 

--- a/dynamic-neural-field-composer/tests/CMakeLists.txt
+++ b/dynamic-neural-field-composer/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "simulation/test_simulation_extended.cpp"
             "simulation/test_simulation_file_manager.cpp"
             "simulation/test_simulation_recorder.cpp"
+            "simulation/test_thread_safety.cpp"
             # tools
             "tools/test_logger.cpp"
             "tools/test_math.cpp"

--- a/dynamic-neural-field-composer/tests/simulation/test_thread_safety.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_thread_safety.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+#include <string>
+#include <atomic>
+
+#include "simulation/simulation.h"
+#include "tools/utils.h"
+
+using namespace dnf_composer;
+
+// Regression tests for the data races reported by the neat-dnfs downstream
+// TSan CI job (.claude/reports/dnf_composer-tsan-data-races.md):
+//   1. Simulation::generateUniqueIdentifier() racing on std::localtime's
+//      shared static buffer.
+//   2. getResourceRoot()'s magic-static initialization racing with itself.
+// These pass trivially on a normal build; the point is to reproduce the
+// races under ThreadSanitizer.
+
+TEST(ThreadSafety, ConcurrentSimulationConstructionDoesNotRace)
+{
+    constexpr int kThreads = 8;
+    constexpr int kIterationsPerThread = 20;
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int i = 0; i < kThreads; ++i)
+    {
+        threads.emplace_back([]()
+        {
+            for (int j = 0; j < kIterationsPerThread; ++j)
+            {
+                Simulation sim("", 1.0, 0.0, 0.0);
+                EXPECT_FALSE(sim.getUniqueIdentifier().empty());
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+}
+}
+
+TEST(ThreadSafety, ConcurrentGetResourceRootDoesNotRace)
+{
+    constexpr int kThreads = 8;
+
+    std::vector<std::thread> threads;
+    std::vector<std::string> results(kThreads);
+    threads.reserve(kThreads);
+
+    for (int i = 0; i < kThreads; ++i)
+    {
+        threads.emplace_back([i, &results]()
+        {
+            results[i] = tools::utils::getResourceRoot();
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+}
+
+    for (const auto& result : results) {
+        EXPECT_EQ(result, results.front());
+}
+}


### PR DESCRIPTION
## Summary
- Fixes two data races: `std::localtime`'s shared
  static buffer in `generateUniqueIdentifier()` / `makeTimestamp()`, and
  `getResourceRoot()`'s magic-static initialization racing under some toolchains
- Fixes a third: `LogWindow`'s shared `logs` vector was mutated/read without locking, and
  `Logger::log()` reassigned a shared global `Logger` instance — since every
  `Simulation` construction logs a message, concurrent construction reliably
  corrupted the heap (reproduced outside any sanitizer)
- Adds a `tsan` leg to CI alongside the existing ASan+UBSan job so this class of
  regression is caught going forward

## Root causes & fixes
- `Simulation::generateUniqueIdentifier()` / `SimulationRecorder`'s timestamp
  helper → switched from `std::localtime` to the existing reentrant
  `tools::utils::safe_localtime()` helper
- `tools::utils::getResourceRoot()` → magic-static init replaced with an
  explicit `std::call_once`
- `LogWindow::addLog()` / `renderContent()` / `clean()` → guarded the shared
  `logs` vector with a mutex
- `Logger::log()` → no longer mutates a shared global `Logger`; builds and logs
  a local instance instead (the now-unused shared instance was removed)

## Test plan
- [x] Added `tests/simulation/test_thread_safety.cpp`: concurrent `Simulation`
      construction and concurrent `getResourceRoot()` calls across 8 threads
- [x] Full test suite passes locally (931/931)
- [x] Stress-ran the new tests 10x with no failures (previously crashed
      reliably with heap corruption before the logging fix)
- [ ] CI: new `tsan` matrix leg should pass alongside existing ASan+UBSan leg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety during concurrent simulation use, logging, timestamp generation, and resource initialization.
  * Prevented potential data races and ensured consistent simulation identifiers and resource paths.

* **Tests**
  * Added multithreaded regression tests covering concurrent simulation construction and resource access.

* **CI**
  * Expanded sanitizer testing to include ThreadSanitizer alongside AddressSanitizer and UndefinedBehaviorSanitizer.

* **Documentation**
  * Updated the changelog with the concurrency fixes and enhanced sanitizer coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->