### PR TITLE
Guard against missing element in getComponent and getComponentPtr

### DIFF
--- a/dynamic-neural-field-composer/src/simulation/simulation.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation.cpp
@@ -453,12 +453,22 @@ namespace dnf_composer
 	std::vector<double> Simulation::getComponent(const std::string& id, const std::string& componentName) const
 	{
 		const std::shared_ptr<element::Element> foundElement = getElement(id);
+		if (!foundElement)
+		{
+			log(tools::logger::LogLevel::FATAL, "Element '" + id + "' was not found and consequently no component was returned.");
+			return {};
+		}
 		return foundElement->getComponent(componentName);
 	}
 
 	std::vector<double>* Simulation::getComponentPtr(const std::string& id, const std::string& componentName) const
 	{
 		const std::shared_ptr<element::Element> foundElement = getElement(id);
+		if (!foundElement)
+		{
+			log(tools::logger::LogLevel::FATAL, "Element '" + id + "' was not found and consequently no component was returned.");
+			return nullptr;
+		}
 		return foundElement->getComponentPtr(componentName);
 	}
 

--- a/dynamic-neural-field-composer/tests/simulation/test_simulation.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_simulation.cpp
@@ -294,6 +294,19 @@ TEST(SimulationComponents, GetComponentPtrReturnsNonNull)
     EXPECT_NE(ptr, nullptr);
 }
 
+TEST(SimulationComponents, GetComponentReturnsEmptyForMissingElement)
+{
+    const Simulation sim("s", 1.0, 0.0, 0.0);
+    const auto data = sim.getComponent("nonexistent", "output");
+    EXPECT_TRUE(data.empty());
+}
+
+TEST(SimulationComponents, GetComponentPtrReturnsNullForMissingElement)
+{
+    const Simulation sim("s", 1.0, 0.0, 0.0);
+    EXPECT_EQ(sim.getComponentPtr("nonexistent", "output"), nullptr);
+}
+
 // ---------------------------------------------------------------------------
 // Time / parameter setters
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What and why

`Simulation::getComponent` and `getComponentPtr` call `getElement(id)` and dereference the result without checking it. `getElement` returns `nullptr` when no element matches the id, so requesting a component for an unknown element (directly, or indirectly through a plot that still references a removed element) crashes. This mirrors the guard that `createInteraction` already has: log a FATAL and return instead of dereferencing. `getComponent` now returns an empty vector and `getComponentPtr` returns `nullptr`. Fixes #37.

## How to verify

Build and run the tests:

```bash
ctest --build-config Release --output-on-failure
```

`GetComponentReturnsEmptyForMissingElement` and `GetComponentPtrReturnsNullForMissingElement` in `tests/simulation/test_simulation.cpp` exercise the missing-element path; without the guard both segfault.

## Checklist

- [x] Tests added or updated
- [ ] Doxygen updated (if public API changed)
- [ ] Wiki updated (if user-visible behaviour changed)
- [x] CI passes (Windows, Linux, macOS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests for components from missing simulation elements.
  * Returns safe empty results instead of causing failures when a requested element cannot be found.
  * Provides clearer fatal error logging for invalid element lookups.

* **Tests**
  * Added coverage for missing-element component and component-pointer queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->