### PR TITLE
fix: validate .dnf fields and fail cleanly on malformed files

### DIFF
--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -557,27 +557,27 @@ namespace dnf_composer
             if (!elementJson.contains("uniqueName") || !elementJson["uniqueName"].is_string())
             {
                 log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
-                    + " is missing a valid \"uniqueName\": " + filePath);
+                    + R"( is missing a valid "uniqueName": )" + filePath);
                 return;
             }
             if (!elementJson.contains("label") || !elementJson["label"].is_array()
                 || elementJson["label"].size() != 2 || !elementJson["label"][1].is_string())
             {
                 log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
-                    + " has a missing or malformed \"label\" (expected a 2-element array): " + filePath);
+                    + R"( has a missing or malformed "label" (expected a 2-element array): )" + filePath);
                 return;
             }
             if (!elementJson.contains("x_max") || !elementJson["x_max"].is_number()
                 || !elementJson.contains("d_x") || !elementJson["d_x"].is_number())
             {
                 log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
-                    + " is missing a valid \"x_max\" or \"d_x\": " + filePath);
+                    + R"( is missing a valid "x_max" or "d_x": )" + filePath);
                 return;
             }
             if (elementJson["x_max"].get<double>() <= 0.0 || elementJson["d_x"].get<double>() <= 0.0)
             {
                 log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
-                    + " has a non-positive \"x_max\" or \"d_x\" (both must be > 0): " + filePath);
+                    + R"( has a non-positive "x_max" or "d_x" (both must be > 0): )" + filePath);
                 return;
             }
         }

--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -543,6 +543,45 @@ namespace dnf_composer
     // NOLINTNEXTLINE(readability-function-cognitive-complexity) - one branch per element type for JSON deserialization; mirrors elementToJson's structure
     void SimulationFileManager::jsonToElements(const json& jsonElements) const
     {
+        // Validate every element's required common fields up front, before any element
+        // is constructed or added to the live simulation. A malformed entry anywhere in
+        // the file aborts the whole load with a descriptive error instead of throwing
+        // mid-loop and leaving the simulation half-loaded.
+        for (size_t i = 0; i < jsonElements.size(); ++i)
+        {
+            const json& elementJson = jsonElements[i];
+            const std::string elementRef = (elementJson.contains("uniqueName") && elementJson["uniqueName"].is_string())
+                ? "'" + elementJson["uniqueName"].get<std::string>() + "'"
+                : "at index " + std::to_string(i);
+
+            if (!elementJson.contains("uniqueName") || !elementJson["uniqueName"].is_string())
+            {
+                log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
+                    + " is missing a valid \"uniqueName\": " + filePath);
+                return;
+            }
+            if (!elementJson.contains("label") || !elementJson["label"].is_array()
+                || elementJson["label"].size() != 2 || !elementJson["label"][1].is_string())
+            {
+                log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
+                    + " has a missing or malformed \"label\" (expected a 2-element array): " + filePath);
+                return;
+            }
+            if (!elementJson.contains("x_max") || !elementJson["x_max"].is_number()
+                || !elementJson.contains("d_x") || !elementJson["d_x"].is_number())
+            {
+                log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
+                    + " is missing a valid \"x_max\" or \"d_x\": " + filePath);
+                return;
+            }
+            if (elementJson["x_max"].get<double>() <= 0.0 || elementJson["d_x"].get<double>() <= 0.0)
+            {
+                log(tools::logger::ERROR, "Invalid simulation file: element " + elementRef
+                    + " has a non-positive \"x_max\" or \"d_x\" (both must be > 0): " + filePath);
+                return;
+            }
+        }
+
         // Track names already loaded so duplicate uniqueNames in the file are rejected
         // (mirrors the guard in Simulation::addElement). Used by both passes below.
         std::unordered_set<std::string> seenNames;

--- a/dynamic-neural-field-composer/tests/simulation/test_simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_simulation_file_manager.cpp
@@ -1431,3 +1431,147 @@ TEST_F(SimulationFileManagerTest, LoadRejectsDuplicateElementNames)
     // the kept "nf 1": the kept field has no inputs.
     EXPECT_TRUE(sim->getElement("nf 1")->getInputs().empty());
 }
+
+// ---------------------------------------------------------------------------
+// Malformed .dnf files fail cleanly instead of crashing (issue #39)
+// ---------------------------------------------------------------------------
+
+TEST_F(SimulationFileManagerTest, LoadRejectsElementMissingUniqueName)
+{
+    // Hand-edited / truncated file: the element object has no "uniqueName" at all.
+    const std::string dir = tempDir + "missing-name/";
+    fs::create_directories(dir);
+    const std::string path = dir + "missing-name.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "missing-name",
+            "deltaT": 1.0,
+            "elements": [
+                { "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "inputs": [] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("missing-name-load", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    EXPECT_NO_THROW(sfm.loadElementsFromJson());
+    EXPECT_EQ(sim->getNumberOfElements(), 0);
+}
+
+TEST_F(SimulationFileManagerTest, LoadRejectsMalformedLabelArray)
+{
+    // "label" must be a 2-element array [enumValue, name]; here it's a bare string.
+    const std::string dir = tempDir + "bad-label/";
+    fs::create_directories(dir);
+    const std::string path = dir + "bad-label.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "bad-label",
+            "deltaT": 1.0,
+            "elements": [
+                { "uniqueName": "nf 1", "label": "neural field",
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "inputs": [] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("bad-label-load", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    EXPECT_NO_THROW(sfm.loadElementsFromJson());
+    EXPECT_EQ(sim->getNumberOfElements(), 0);
+}
+
+TEST_F(SimulationFileManagerTest, LoadRejectsNonPositiveDimensions)
+{
+    // d_x <= 0 must be rejected rather than propagating into a division (size_x = x_max/d_x).
+    const std::string dir = tempDir + "bad-dims/";
+    fs::create_directories(dir);
+    const std::string path = dir + "bad-dims.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "bad-dims",
+            "deltaT": 1.0,
+            "elements": [
+                { "uniqueName": "nf 1", "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 0.0, "tau": 25.0, "restingLevel": -5.0,
+                  "inputs": [] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("bad-dims-load", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    EXPECT_NO_THROW(sfm.loadElementsFromJson());
+    EXPECT_EQ(sim->getNumberOfElements(), 0);
+}
+
+TEST_F(SimulationFileManagerTest, LoadOfMalformedFileDoesNotPartiallyLoadEarlierElements)
+{
+    // Two well-formed elements are listed BEFORE a malformed third one. If the file
+    // were validated element-by-element while constructing (the old behaviour), the
+    // first two would already be added to the simulation by the time the third one
+    // throws, leaving a half-loaded simulation. The fix validates every element up
+    // front, so a malformed entry anywhere aborts the load before anything is added.
+    const std::string dir = tempDir + "partial-load/";
+    fs::create_directories(dir);
+    const std::string path = dir + "partial-load.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "partial-load",
+            "deltaT": 1.0,
+            "elements": [
+                { "uniqueName": "nf 1", "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "inputs": [] },
+                { "uniqueName": "gk 1", "label": [3, "gauss kernel"],
+                  "x_max": 100, "d_x": 1.0, "amplitude": 10.0, "width": 5.0,
+                  "circular": true, "normalized": true, "amplitudeGlobal": 0.0,
+                  "inputs": [] },
+                { "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "inputs": [] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("partial-load-sim", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    EXPECT_NO_THROW(sfm.loadElementsFromJson());
+    EXPECT_EQ(sim->getNumberOfElements(), 0);
+    EXPECT_EQ(sim->getElement("nf 1"), nullptr);
+    EXPECT_EQ(sim->getElement("gk 1"), nullptr);
+}
+
+TEST_F(SimulationFileManagerTest, LoadWellFormedFileStillSucceedsAfterValidationGuards)
+{
+    // Sanity check: the new up-front validation must not reject a normal, well-formed file.
+    const std::string dir = tempDir + "well-formed/";
+    fs::create_directories(dir);
+    const std::string path = dir + "well-formed.dnf";
+    {
+        std::ofstream f(path);
+        f << R"({
+            "identifier": "well-formed",
+            "deltaT": 1.0,
+            "elements": [
+                { "uniqueName": "nf 1", "label": [0, "neural field"],
+                  "x_max": 100, "d_x": 1.0, "tau": 25.0, "restingLevel": -5.0,
+                  "activationFunction": { "type": "sigmoid", "x_shift": 0.0, "steepness": 10.0 },
+                  "inputs": [] }
+            ]
+        })";
+    }
+
+    const auto sim = createSimulation("well-formed-load", 1.0, 0.0, 0.0);
+    const SimulationFileManager sfm{ sim, path };
+    EXPECT_NO_THROW(sfm.loadElementsFromJson());
+    EXPECT_EQ(sim->getNumberOfElements(), 1);
+    EXPECT_NE(sim->getElement("nf 1"), nullptr);
+}


### PR DESCRIPTION
Closes #39.

## Problem
A malformed or truncated `.dnf` file crashed deserialization with an unhandled exception (`nlohmann::json::type_error` / `out_of_range`) instead of failing cleanly, and could leave the simulation half-loaded. Required fields (`uniqueName`, `label`, `x_max`, `d_x`) were accessed directly with no `.contains()` / array-size / positivity checks.

## Fix
`SimulationFileManager::jsonToElements` now runs a validation pass over **every** element *before* any element is constructed or added to the live simulation:
- `uniqueName` — present and a string
- `label` — present, an array of exactly 2 elements, `label[1]` a string
- `x_max` / `d_x` — present, numeric, and both `> 0` (mirrors `Simulation`'s positive-dimension check)

On the first malformation it logs a descriptive `ERROR` naming the offending element (its `uniqueName` if available, else `at index N`) plus the file path, and returns immediately. Because validation is a separate up-front pass, a bad element anywhere aborts the whole load with **no partial mutation** — not even elements listed before the bad one are added.

## Tests
`tests/simulation/test_simulation_file_manager.cpp` — new section for issue #39:
- `LoadRejectsElementMissingUniqueName`
- `LoadRejectsMalformedLabelArray`
- `LoadRejectsNonPositiveDimensions`
- `LoadOfMalformedFileDoesNotPartiallyLoadEarlierElements` (2 valid + 1 malformed ⇒ 0 elements loaded)
- `LoadWellFormedFileStillSucceedsAfterValidationGuards`

All assert clean failure (`EXPECT_NO_THROW` + element count) rather than a crash, following the existing test conventions.

## Verification
New tests 6/6; full suite **977/977** passing, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when loading simulation files.
  * Invalid files are now rejected cleanly when they contain missing or malformed element names, labels, or dimensions.
  * Prevented partially loaded simulations when errors are detected later in a file.
  * Valid simulation files continue to load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->