### PR TITLE
fix: guard gaussNorm against near-zero denominator

### DIFF
--- a/dynamic-neural-field-composer/include/tools/math.h
+++ b/dynamic-neural-field-composer/include/tools/math.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Included before the max/min undef guard below since it transitively drags in
+// <windows.h> (via imgui-platform-kit), which would otherwise redefine those
+// macros again right after the guard clears them.
+#include "tools/logger.h"
+
 //https://github.com/stevenlovegrove/Pangolin/issues/352
 #ifdef max
 #undef max
@@ -225,7 +230,16 @@ namespace dnf_composer::tools::math
 
 		if (!g.empty())
 		{
-			double sumOfG = std::reduce(g.begin(), g.end());
+			static constexpr double epsilon = 1e-12;
+			const double sumOfG = std::reduce(g.begin(), g.end());
+			if (!std::isfinite(sumOfG) || std::abs(sumOfG) < epsilon)
+			{
+				logger::log(logger::LogLevel::WARNING,
+					"gaussNorm: sum of Gaussian is near-zero or non-finite (degenerate sigma?); "
+					"returning un-normalized zero vector to avoid NaN/Inf propagation.");
+				std::fill(g.begin(), g.end(), T());
+				return g;
+			}
 			for (int i = 0; i < g.size(); i++) {
 				g[i] = g[i] / sumOfG;
 }

--- a/dynamic-neural-field-composer/tests/tools/test_math.cpp
+++ b/dynamic-neural-field-composer/tests/tools/test_math.cpp
@@ -133,6 +133,31 @@ TEST(GaussNorm, ValuesAreNonNegative)
         EXPECT_GE(v, 0.0);
 }
 
+TEST(GaussNorm, DegenerateSigmaDoesNotProduceNanOrInf)
+{
+    // sigma -> 0 makes pow(sigma,2) == 0, so the unnormalized Gaussian contains
+    // 0/0 (NaN) and/or divide-by-zero (Inf) terms; the sum-of-Gaussian guard
+    // must catch this and return a finite (zero) vector instead of propagating
+    // NaN/Inf network-wide (issue #42).
+    const std::vector<int> rangeX{ -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 };
+    const auto g = gaussNorm(rangeX, 0.0, 0.0);
+    ASSERT_EQ(g.size(), rangeX.size());
+    for (double v : g)
+        EXPECT_TRUE(std::isfinite(v));
+}
+
+TEST(GaussNorm, NormalCaseStillSumsToOneAfterGuardAdded)
+{
+    // Regression guard: a well-conditioned sigma must be unaffected by the
+    // near-zero/non-finite denominator guard and still normalize to 1.
+    const std::vector<int> rangeX{ -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    const auto g = gaussNorm(rangeX, 0.0, 2.0);
+    for (double v : g)
+        EXPECT_TRUE(std::isfinite(v));
+    const double sum = std::accumulate(g.begin(), g.end(), 0.0);
+    EXPECT_NEAR(sum, 1.0, 1e-9);
+}
+
 // ---------------------------------------------------------------------------
 // sigmoid (template)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #42.

## Problem
`gaussNorm` (`include/tools/math.h`) divided each element by the Gaussian sum `sumOfG` with no guard. On a degenerate width (σ→0) or an otherwise ~0 / non-finite sum, this produced NaN/Inf that then propagated silently through every connected field.

## Fix
Before dividing, guard the denominator:
```cpp
if (!std::isfinite(sumOfG) || std::abs(sumOfG) < epsilon)  // epsilon = 1e-12
{
    logger::log(logger::LogLevel::WARNING, "gaussNorm: sum of Gaussian is near-zero or non-finite ...");
    std::fill(g.begin(), g.end(), T());   // safe, un-normalized zero vector
    return g;
}
```
The warning matches the existing `log(..., WARNING, ...)` convention used across the codebase.

**Include ordering:** `#include "tools/logger.h"` is added at the very top of the header, *before* the existing `#undef max/min` guard block — `logger.h` transitively pulls in `<windows.h>` (via imgui-platform-kit), which would otherwise re-define those macros right after the guard clears them and break `std::min`/`std::max` at ~15 call sites later in the header. Placing it ahead of the guard lets the guard clean up those macros too. (Documented in a comment.)

## Tests
`tests/tools/test_math.cpp` (GaussNorm section):
- `DegenerateSigmaDoesNotProduceNanOrInf` — `gaussNorm(rangeX, 0.0, 0.0)` (previously NaN) now yields all-finite output.
- `NormalCaseStillSumsToOneAfterGuardAdded` — well-conditioned case unaffected (finite, sums to ≈1 within 1e-9).

## Verification
4/4 (warning fires exactly once on the degenerate case); full suite **974/974** passing, no regressions.