### PR TITLE
fix: surface SimulationRecorder I/O failures and don't enter recording state

### DIFF
--- a/dynamic-neural-field-composer/include/simulation/simulation_recorder.h
+++ b/dynamic-neural-field-composer/include/simulation/simulation_recorder.h
@@ -34,12 +34,18 @@ namespace dnf_composer
 		/// @brief Start a new continuous recording for the given element/component pair.
 		/// Creates `data/<simName>/recordings/<elementId>_<componentName>_<timestamp>.csv`
 		/// and writes the header row. No-op if an identical recording is already active.
+		///
+		/// On failure (directory could not be created, or the file could not be opened)
+		/// a distinct, descriptive error is logged and no session is created — the
+		/// recorder does NOT enter the "recording" state, so @ref isRecording and
+		/// @ref hasActiveRecordings continue to reflect reality.
 		/// @param simName         Simulation unique identifier (used as the sub-folder name).
 		/// @param elementId       Unique name of the element to record.
 		/// @param componentName   Name of the component vector (e.g. "activation").
 		/// @param sampleInterval  How often to sample (in the chosen unit).
 		/// @param unit            Whether @p sampleInterval is in ticks or milliseconds.
-		void startRecording(const std::string& simName,
+		/// @return true if the recording session was started successfully, false otherwise.
+		bool startRecording(const std::string& simName,
 		                    const std::string& elementId,
 		                    const std::string& componentName,
 		                    int sampleInterval,

--- a/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
@@ -79,11 +79,18 @@ namespace dnf_composer
 
 		std::error_code ec;
 		std::filesystem::create_directories(dir, ec);
-		if (ec || !std::filesystem::is_directory(dir))
+		if (ec)
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
 				R"(Recording not started: failed to create recording directory ")" + dir.string() +
 				R"(" ()" + ec.message() + ").");
+			return false;
+		}
+		if (!std::filesystem::is_directory(dir, ec))
+		{
+			tools::logger::log(tools::logger::LogLevel::ERROR,
+				R"(Recording not started: ")" + dir.string() + R"(" is not a directory)" +
+				(ec ? " (" + ec.message() + ")." : "."));
 			return false;
 		}
 

--- a/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cmath>
+#include <system_error>
 
 namespace dnf_composer
 {
@@ -59,7 +60,7 @@ namespace dnf_composer
 		file << "\n";
 	}
 
-	void SimulationRecorder::startRecording(const std::string& simName,
+	bool SimulationRecorder::startRecording(const std::string& simName,
 	                                        const std::string& elementId,
 	                                        const std::string& componentName,
 	                                        const int sampleInterval,
@@ -69,12 +70,21 @@ namespace dnf_composer
 		{
 			tools::logger::log(tools::logger::LogLevel::WARNING,
 				"Recording already active for '" + elementId + "' / '" + componentName + "'.");
-			return;
+			return false;
 		}
 
 		const std::filesystem::path dir = std::filesystem::path(tools::utils::getResourceRoot())
 			/ "data" / simName / "recordings";
-		std::filesystem::create_directories(dir);
+
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		if (ec || !std::filesystem::is_directory(dir))
+		{
+			tools::logger::log(tools::logger::LogLevel::ERROR,
+				R"(Recording not started: failed to create recording directory ")" + dir.string() +
+				R"(" ()" + ec.message() + ").");
+			return false;
+		}
 
 		const std::string filename = (dir / (elementId + "_" + componentName + "_" + makeTimestamp() + ".csv")).string();
 
@@ -89,14 +99,16 @@ namespace dnf_composer
 		if (!session.file.is_open())
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
-				"Failed to open recording file: " + filename);
-			return;
+				R"(Recording not started: failed to open recording file ")" + filename +
+				R"(" (check disk space and write permissions).)");
+			return false;
 		}
 
 		tools::logger::log(tools::logger::LogLevel::INFO,
 			"Recording started: " + filename);
 
 		sessions.push_back(std::move(session));
+		return true;
 	}
 
 	void SimulationRecorder::stopRecording(const std::string& elementId,

--- a/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
@@ -71,7 +71,7 @@ namespace dnf_composer
 		{
 			tools::logger::log(tools::logger::LogLevel::WARNING,
 				std::format("Recording already active for '{}' / '{}'.", elementId, componentName));
-			return;
+			return false;
 		}
 
 		const std::filesystem::path dir = std::filesystem::path(tools::utils::getResourceRoot())

--- a/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/simulation_window.cpp
@@ -2117,6 +2117,11 @@ namespace dnf_composer::user_interface
 				}
 
 				if (startPressed) {
+					// startRecording() returns false and logs a distinct error (visible in the
+					// log window) when the directory could not be created or the file could not
+					// be opened; it does not enter the "recording" state in that case, so
+					// currentlyRecording/canStart above will correctly reflect the failure on
+					// the next frame — no extra UI bookkeeping is needed here.
 					simulation->getRecorder().startRecording(
 						simulation->getUniqueIdentifier(),
 						selectedElementId, selectedComponent,

--- a/dynamic-neural-field-composer/tests/simulation/test_simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_simulation_recorder.cpp
@@ -424,3 +424,74 @@ TEST(SimulationRecorderTicks, TicksMatchStepCount)
     EXPECT_EQ(lastTick, targetSteps);
     cleanSimDir(simId);
 }
+
+// ---------------------------------------------------------------------------
+// I/O failure surfacing (issue #43): startRecording() must report failure and
+// must not leave the recorder in the "recording" state when the directory
+// cannot be created or the file cannot be opened.
+// ---------------------------------------------------------------------------
+
+TEST(SimulationRecorderFailure, StartRecordingSucceedsAndReturnsTrueForValidPath)
+{
+    const std::string simId = "rec-return-true-happy-path";
+    cleanSimDir(simId);
+    auto sim = makeRunningSimulation(simId);
+
+    const bool started =
+        sim->getRecorder().startRecording(simId, "stim", "output", 1, RecordingIntervalUnit::Ticks);
+
+    EXPECT_TRUE(started);
+    EXPECT_TRUE(sim->getRecorder().isRecording("stim", "output"));
+    EXPECT_TRUE(sim->getRecorder().hasActiveRecordings());
+
+    sim->getRecorder().stopAll();
+    cleanSimDir(simId);
+}
+
+TEST(SimulationRecorderFailure, StartRecordingFailsWhenRecordingDirectoryIsBlockedByAFile)
+{
+    const std::string simId = "rec-dir-blocked-by-file";
+    cleanSimDir(simId);
+    auto sim = makeRunningSimulation(simId);
+
+    // Pre-create a regular file at the exact path the "recordings" directory would
+    // need to occupy, so std::filesystem::create_directories() cannot succeed.
+    const fs::path simDir = fs::path(tools::utils::getResourceRoot()) / "data" / simId;
+    fs::create_directories(simDir);
+    const fs::path blockedRecordingsPath = simDir / "recordings";
+    {
+        std::ofstream blocker(blockedRecordingsPath);
+        blocker << "not a directory";
+    }
+
+    const bool started =
+        sim->getRecorder().startRecording(simId, "stim", "output", 1, RecordingIntervalUnit::Ticks);
+
+    EXPECT_FALSE(started);
+    EXPECT_FALSE(sim->getRecorder().isRecording("stim", "output"));
+    EXPECT_FALSE(sim->getRecorder().hasActiveRecordings());
+
+    cleanSimDir(simId);
+}
+
+TEST(SimulationRecorderFailure, StartRecordingFailsWhenFileCannotBeOpened)
+{
+    const std::string simId = "rec-file-open-fails";
+    cleanSimDir(simId);
+
+    SimulationRecorder rec;
+
+    // Embedding a path separator in the element id makes the recorder target a
+    // filename inside a subdirectory ("recordings/missing/...") that was never
+    // created, so directory creation succeeds but std::ofstream::open() fails.
+    // This exercises the file-open failure path distinctly from the
+    // directory-creation failure path above.
+    const bool started =
+        rec.startRecording(simId, "missing/elem", "output", 1, RecordingIntervalUnit::Ticks);
+
+    EXPECT_FALSE(started);
+    EXPECT_FALSE(rec.isRecording("missing/elem", "output"));
+    EXPECT_FALSE(rec.hasActiveRecordings());
+
+    cleanSimDir(simId);
+}


### PR DESCRIPTION
Closes #43.

## Problem
`SimulationRecorder::startRecording` called `create_directories` (throwing overload, result never checked) then opened the file; on failure it logged and returned `void`, so the user believed recording was active while nothing was written — `isRecording`/`hasActiveRecordings` didn't reflect the failure.

## Fix
- `startRecording` now returns **`bool`** (was `void`) and returns `false` on every failure path *before* a `Session` is constructed/pushed — so `isRecording()`/`hasActiveRecordings()` reflect reality by construction.
- **Directory failure:** use the non-throwing `create_directories(dir, ec)` overload + a `!is_directory(dir)` belt-and-braces check; log a distinct message with the path and `ec.message()`.
- **File-open failure:** distinct message naming the file (hints at disk space / permissions).
- Both messages use raw string literals (clang-tidy clean).
- **GUI** (`simulation_window.cpp`): `currentlyRecording`/`canStart` are recomputed from `isRecording()` each frame and the distinct error text surfaces in the log window, so a failed start no longer shows an active session. (Deliberately did not add `[[nodiscard]]` to avoid breaking the many existing call sites that ignore the result under clang-tidy `WarningsAsErrors`.)

## Tests
`tests/simulation/test_simulation_recorder.cpp` — new `SimulationRecorderFailure` suite:
- valid path ⇒ returns `true`, both flags true;
- directory blocked by a pre-existing regular file ⇒ returns `false`, both flags false;
- directory OK but file cannot be opened (nested path via `/` in id) ⇒ returns `false` — exercises the second branch distinctly, portable across POSIX/Windows.

## Verification
18/18; full suite **975/975**, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recording startup reliability by detecting directory-creation and output-file failures.
  - Recording now remains inactive when setup fails, preventing misleading recording states.
  - Prevented attempts to start a second recording while one is already active.
  - Improved error reporting for recording setup problems.

- **Improvements**
  - Recording startup now clearly reports whether initialization succeeded, allowing the interface to reflect the correct state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->