### PR TITLE
fix: quick-populate 2D neural fields as heatmaps

### DIFF
--- a/dynamic-neural-field-composer/include/user_interface/plot_control_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/plot_control_window.h
@@ -17,6 +17,13 @@
 
 namespace dnf_composer::user_interface
 {
+	/// @brief Pick the plot type quick-populate should use for a given element.
+	///
+	/// A 2D neural field cannot be represented by a line plot, so it is shown
+	/// as a heatmap instead; every other (1D) field keeps the classic line plot.
+	/// Pure decision logic, kept free of ImGui so it can be unit-tested headlessly.
+	[[nodiscard]] PlotType quickPopulatePlotTypeFor(const std::shared_ptr<element::Element>& element);
+
 	class PlotControlWindow final : public imgui_kit::UserInterfaceWindow
 	{
 	private:

--- a/dynamic-neural-field-composer/src/dynamic-neural-field-composer-dynamic.cpp
+++ b/dynamic-neural-field-composer/src/dynamic-neural-field-composer-dynamic.cpp
@@ -23,6 +23,7 @@ int main()
 		app.addWindow<user_interface::SimulationWindow>();
 		app.addWindow<user_interface::ElementWindow>();
 		app.addWindow<user_interface::FieldMetricsWindow>();
+		app.addWindow<user_interface::PlotControlWindow>();
 		app.addWindow<user_interface::PlotsWindow>();
 		app.addWindow<user_interface::NodeGraphWindow>();
 		app.addWindow<user_interface::LogWindow>();

--- a/dynamic-neural-field-composer/src/user_interface/plot_control_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/plot_control_window.cpp
@@ -6,6 +6,13 @@
 
 namespace dnf_composer::user_interface
 {
+	PlotType quickPopulatePlotTypeFor(const std::shared_ptr<element::Element>& element)
+	{
+		return element->getLabel() == element::ElementLabel::NEURAL_FIELD_2D
+			? PlotType::HEATMAP
+			: PlotType::LINE_PLOT;
+	}
+
 	PlotControlWindow::PlotControlWindow(const std::shared_ptr<Visualization>& visualization)
 		:visualization(visualization), simulation(visualization->getSimulation())
 	{}
@@ -24,7 +31,8 @@ namespace dnf_composer::user_interface
 				visualization->plot(selectedPlotType);
 			}
 
-		// Quick-populate: one line plot per neural field with all its components
+		// Quick-populate: one line plot per 1D neural field (all its components),
+		// one heatmap per component for every 2D neural field.
 
 		ImGui::SameLine(0, 48);
 		ImGui::Text("Quick-populate:"); ImGui::SameLine();
@@ -33,7 +41,7 @@ namespace dnf_composer::user_interface
 		const bool clicked = ImGui::Button(ICON_FA_WAVE_SQUARE "##plotfields");
 		ImGui::PopFont();
 		if (ImGui::IsItemHovered()) {
-			ImGui::SetTooltip("Add one line plot per neural field,\nwith all its components plotted.");
+			ImGui::SetTooltip("Add one line plot per 1D neural field, with all its components plotted,\nand one heatmap per component for every 2D neural field.");
 }
 		if (clicked)
 		{
@@ -47,7 +55,9 @@ namespace dnf_composer::user_interface
 
 			for (const auto& element : simulation->getElements())
 			{
-				if (element->getLabel() != element::ElementLabel::NEURAL_FIELD) {
+				const bool isNeuralField = element->getLabel() == element::ElementLabel::NEURAL_FIELD ||
+					element->getLabel() == element::ElementLabel::NEURAL_FIELD_2D;
+				if (!isNeuralField) {
 					continue;
 }
 				if (alreadyPlotted.contains(element->getUniqueName())) {
@@ -57,6 +67,23 @@ namespace dnf_composer::user_interface
 				if ((comps == nullptr) || comps->empty()) {
 					continue;
 }
+
+				if (quickPopulatePlotTypeFor(element) == PlotType::HEATMAP)
+				{
+					// A single heatmap can only visualize one 2D component,
+					// so add one heatmap per component instead of combining them.
+					for (const auto& componentName : *comps | std::views::keys)
+					{
+						visualization->plot(
+							PlotCommonParameters{PlotType::HEATMAP,
+								PlotAnnotations{element->getUniqueName() + " - " + componentName,
+									"Spatial dimension (x)", "Spatial dimension (y)"}},
+							HeatmapParameters{},
+							element->getUniqueName(), componentName);
+					}
+					continue;
+				}
+
 				// Create the plot with the first component, then append the rest
 				auto it = comps->begin();
 				visualization->plot(element->getUniqueName(), it->first);

--- a/dynamic-neural-field-composer/tests/CMakeLists.txt
+++ b/dynamic-neural-field-composer/tests/CMakeLists.txt
@@ -58,6 +58,8 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "exceptions/test_exception.cpp"
             # visualization
             "visualization/test_visualization.cpp"
+            # user_interface
+            "user_interface/test_plot_control_window.cpp"
     )
     target_include_directories(dnf_composer_tests PRIVATE
             ${CMAKE_SOURCE_DIR}/include

--- a/dynamic-neural-field-composer/tests/user_interface/test_plot_control_window.cpp
+++ b/dynamic-neural-field-composer/tests/user_interface/test_plot_control_window.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "user_interface/plot_control_window.h"
+#include "elements/neural_field.h"
+#include "elements/neural_field_2d.h"
+#include "elements/activation_function.h"
+
+using namespace dnf_composer;
+using namespace dnf_composer::element;
+
+// quickPopulatePlotTypeFor() is the pure decision logic behind the Plot
+// Control window's quick-populate button (see issue #57): it never touches
+// ImGui, so it can be exercised headlessly, unlike PlotControlWindow::render()/
+// renderContent(), which require a live ImGui/OpenGL context and are not
+// unit-testable in this suite.
+
+static std::shared_ptr<NeuralField> make1DField(const std::string& name = "nf-1d")
+{
+    const ElementCommonParameters cp{ name, 50 };
+    const NeuralFieldParameters nfp{ 25.0, -5.0, SigmoidFunction(0.0, 10.0) };
+    return std::make_shared<NeuralField>(cp, nfp);
+}
+
+static std::shared_ptr<NeuralField2D> make2DField(const std::string& name = "nf-2d")
+{
+    const ElementCommonParameters cp{ name, ElementDimensions(10, 10, 1.0, 1.0) };
+    const NeuralField2DParameters nfp{ 25.0, -5.0, SigmoidFunction(0.0, 10.0) };
+    return std::make_shared<NeuralField2D>(cp, nfp);
+}
+
+TEST(QuickPopulatePlotTypeFor, OneDimensionalFieldGetsLinePlot)
+{
+    const auto field = make1DField();
+    EXPECT_EQ(user_interface::quickPopulatePlotTypeFor(field), PlotType::LINE_PLOT);
+}
+
+TEST(QuickPopulatePlotTypeFor, TwoDimensionalFieldGetsHeatmap)
+{
+    const auto field = make2DField();
+    EXPECT_EQ(user_interface::quickPopulatePlotTypeFor(field), PlotType::HEATMAP);
+}
+
+TEST(QuickPopulatePlotTypeFor, LabelMatchesElementDimensionality)
+{
+    const auto field1D = make1DField();
+    const auto field2D = make2DField();
+    EXPECT_EQ(field1D->getLabel(), ElementLabel::NEURAL_FIELD);
+    EXPECT_EQ(field2D->getLabel(), ElementLabel::NEURAL_FIELD_2D);
+    EXPECT_NE(user_interface::quickPopulatePlotTypeFor(field1D),
+              user_interface::quickPopulatePlotTypeFor(field2D));
+}


### PR DESCRIPTION
Closes #57.

## Problem
The Plot control window's Quick-populate handler (`plot_control_window.cpp`) filtered on `ElementLabel::NEURAL_FIELD` only, so `NEURAL_FIELD_2D` elements were silently skipped — a simulation of only 2D fields got nothing. And it always used the line-plot-with-all-components path, which is the wrong representation for a 2D component anyway.

## Fix
- Filter now accepts both `NEURAL_FIELD` and `NEURAL_FIELD_2D`.
- New free function `quickPopulatePlotTypeFor(element)` maps an element to `PlotType::HEATMAP` for `NEURAL_FIELD_2D`, else `PlotType::LINE_PLOT` (mirrors the existing `is2D` label check used in `field_metrics_window.cpp`).
- 2D fields → **one heatmap per component**, using the exact `Visualization::plot(PlotCommonParameters{HEATMAP,…}, HeatmapParameters{}, name, component)` path already used by every `examples/*_2d.cpp` (e.g. `travelling_bump_2d.cpp`) — no new visualization code.
- 1D fields keep the original one-line-plot-all-components behavior. Tooltip/comment updated.

## Tests
`PlotControlWindow::renderContent()` isn't headless-testable (unconditional ImGui calls need a live context), so the pure decision logic was extracted into the testable `quickPopulatePlotTypeFor()`. New `tests/user_interface/test_plot_control_window.cpp` (registered in `tests/CMakeLists.txt`): 1D field → `LINE_PLOT`, 2D field → `HEATMAP`, and the two differ.

Manual/GUI check: load a 2D-only simulation, click the quick-populate button → one heatmap window per component appears (was: nothing).

## Verification
Clean build; full suite **975/975** (3 new + 972), no regressions.