### PR TITLE
fix: rebuild stale input cache after a connected source is resized

### DIFF
--- a/dynamic-neural-field-composer/include/elements/element.h
+++ b/dynamic-neural-field-composer/include/elements/element.h
@@ -32,10 +32,22 @@ namespace dnf_composer::element
 		std::unordered_map<std::shared_ptr<Element>, std::string> inputs;   ///< Upstream elements and the component they expose.
 		std::unordered_map<std::shared_ptr<Element>, std::string> outputs;  ///< Downstream elements that read this element's output.
 	private:
-		struct CachedInput { const double* src; std::size_t size; };
-		std::vector<CachedInput> cachedInputs;
+		// Caches a pointer to each connected input's *vector object* (not a raw
+		// data() snapshot). A std::vector stored as an unordered_map value keeps its
+		// address stable across resizes (only its internal buffer reallocates), so
+		// re-reading ->size()/data() from it on every updateInput() call can never
+		// dangle -- it always reflects the source's current dimensions, even if the
+		// source was resized via changeDimensions() after this cache was built.
+		std::vector<const std::vector<double>*> cachedInputs;
 		double*     inputPtr  = nullptr;
 		std::size_t inputSize = 0;
+
+		/// @brief Remove any input whose source component no longer fits within
+		///        this element's "input" buffer (e.g. the source was resized larger
+		///        via changeDimensions() after the cache was built, so accumulating
+		///        it in full would write out-of-bounds). Logs a warning per severed
+		///        connection and forces a cache rebuild on the next updateInput().
+		void severIncompatibleInputs();
 	public:
 		/// @brief Construct an element with the given common parameters.
 		/// @param parameters  Name, label, and spatial dimensions.

--- a/dynamic-neural-field-composer/src/elements/element.cpp
+++ b/dynamic-neural-field-composer/src/elements/element.cpp
@@ -180,8 +180,7 @@ namespace dnf_composer::element
 		cachedInputs.reserve(inputs.size());
 		for (const auto& [elem, compName] : inputs)
 		{
-			const auto& compVec = elem->components.at(compName);
-			cachedInputs.push_back({compVec.data(), compVec.size()});
+			cachedInputs.push_back(&elem->components.at(compName));
 		}
 	}
 
@@ -194,30 +193,87 @@ namespace dnf_composer::element
 		// Sum the input sources into the input buffer. Copy the first source
 		// instead of zero-filling then adding it — this elides a full zero-fill
 		// pass over the buffer every step (updateInput runs for every element).
-		// Bit-identical to fill(0) + accumulate. Sources are same-sized as the
-		// input buffer (enforced at addInput); guard defensively all the same.
+		// Bit-identical to fill(0) + accumulate. Re-derive size/data from each
+		// cached vector *object* on every call rather than trusting a size
+		// snapshot taken when the cache was built: if the source was resized via
+		// changeDimensions() since then, its buffer may have been reallocated,
+		// but the vector object itself is stable, so this can never read a
+		// dangling pointer -- only ever the source's current data. Some elements
+		// (e.g. a circular GaussKernel) legitimately keep an "input" buffer
+		// larger than the connected source's component -- that extra room is
+		// padding, not a mismatch -- so only a source that grew *past* inputSize
+		// is unsafe to accumulate in full; anything else fits.
 		if (cachedInputs.empty())
 		{
 			std::fill_n(inputPtr, inputSize, 0.0);
 			return;
 		}
 
-		const CachedInput& first = cachedInputs.front();
-		const std::size_t n0 = first.size < inputSize ? first.size : inputSize;
-		for (std::size_t i = 0; i < n0; ++i) {
-			inputPtr[i] = first.src[i];
-		}
-		for (std::size_t i = n0; i < inputSize; ++i) {
-			inputPtr[i] = 0.0;
+		bool incompatibleSourceFound = false;
+		std::size_t firstIndex = 0;
+		for (; firstIndex < cachedInputs.size(); ++firstIndex)
+		{
+			if (cachedInputs[firstIndex]->size() <= inputSize) {
+				break;
+}
+			incompatibleSourceFound = true;
 		}
 
-		for (std::size_t k = 1; k < cachedInputs.size(); ++k)
+		if (firstIndex == cachedInputs.size())
 		{
-			const CachedInput& in = cachedInputs[k];
-			for (std::size_t i = 0; i < in.size; ++i) {
-				inputPtr[i] += in.src[i];
+			std::fill_n(inputPtr, inputSize, 0.0);
+		}
+		else
+		{
+			const std::vector<double>& first = *cachedInputs[firstIndex];
+			const std::size_t n0 = first.size() < inputSize ? first.size() : inputSize;
+			for (std::size_t i = 0; i < n0; ++i) {
+				inputPtr[i] = first[i];
+			}
+			for (std::size_t i = n0; i < inputSize; ++i) {
+				inputPtr[i] = 0.0;
+			}
+
+			for (std::size_t k = firstIndex + 1; k < cachedInputs.size(); ++k)
+			{
+				const std::vector<double>& srcVec = *cachedInputs[k];
+				if (srcVec.size() > inputSize)
+				{
+					incompatibleSourceFound = true;
+					continue;
+				}
+				for (std::size_t i = 0; i < srcVec.size(); ++i) {
+					inputPtr[i] += srcVec[i];
+				}
 			}
 		}
+
+		if (incompatibleSourceFound) {
+			severIncompatibleInputs();
+}
+	}
+
+	void Element::severIncompatibleInputs()
+	{
+		std::vector<std::shared_ptr<Element>> toSever;
+		for (const auto& [elem, compName] : inputs)
+		{
+			if (elem->components.at(compName).size() > inputSize) {
+				toSever.push_back(elem);
+}
+		}
+
+		for (const auto& elem : toSever)
+		{
+			const std::string logMessage = R"(Input ")" + elem->getUniqueName() +
+				R"(" no longer matches the size of ")" + getUniqueName() +
+				R"(" after being resized; severing the connection.)";
+			log(tools::logger::LogLevel::WARNING, logMessage);
+			elem->outputs.erase(this->shared_from_this());
+			inputs.erase(elem);
+		}
+
+		inputPtr = nullptr; // inputs changed; rebuild cache on next updateInput()
 	}
 
 	int Element::getMaxSpatialDimension() const

--- a/dynamic-neural-field-composer/tests/elements/test_change_dimensions.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_change_dimensions.cpp
@@ -324,3 +324,80 @@ TEST(ChangeDimensions, ResizeUpThenDown)
     EXPECT_EQ(el->getSize(), 50);
     EXPECT_EQ(el->getComponent("output").size(), 50u);
 }
+
+// ---------------------------------------------------------------------------
+// Resizing a connected SOURCE must not leave a stale/dangling input cache on
+// the downstream element (#40). Element::buildInputCache() caches a source
+// component for each input; changeDimensions() on the source reallocates that
+// component's buffer without the downstream element being touched at all.
+// ---------------------------------------------------------------------------
+
+TEST(ChangeDimensions, ConnectedSourceResizeIsSafelySevered)
+{
+    // sink (NeuralField) reads source's (GaussStimulus) "output" as its "input".
+    const auto source = makeGaussStimulus(100);
+    const auto sink = makeNeuralField(100);
+    sink->addInput(source, "output");
+
+    source->init();
+    sink->init();
+
+    // Step so Element::buildInputCache() runs and caches source's "output"
+    // component for sink.
+    EXPECT_NO_THROW(source->step(0.0, 1.0));
+    EXPECT_NO_THROW(sink->step(0.0, 1.0));
+    ASSERT_TRUE(sink->hasInput());
+
+    // Resize the SOURCE (not the sink) to a much larger size. GaussStimulus's
+    // "output" vector must reallocate to grow. With the old implementation,
+    // Element::updateInput() kept using a raw const double* + size snapshot
+    // taken before this resize: the pointer would dangle (freed buffer) and
+    // the cached size would no longer match sink's actual "input" buffer,
+    // producing an out-of-bounds/use-after-free read.
+    EXPECT_NO_THROW(source->changeDimensions(dim(5000)));
+
+    // Stepping again must not crash or corrupt memory. Because 5000 != 100,
+    // the connection can no longer be safely revalidated, so it must be
+    // severed (with a logged warning) instead of read out-of-bounds. This is
+    // the one assertion that reliably distinguishes old vs. new behavior:
+    // the old code never inspects/severs a downstream connection when the
+    // *source* (not the sink itself) is resized, so hasInput() would stay
+    // true forever and the stale cache would keep being dereferenced.
+    EXPECT_NO_THROW(source->step(0.0, 1.0));
+    EXPECT_NO_THROW(sink->step(0.0, 1.0));
+
+    EXPECT_FALSE(sink->hasInput());
+    EXPECT_FALSE(source->hasOutput());
+    EXPECT_EQ(sink->getComponent("input").size(), 100u);   // sink's own buffer untouched
+    EXPECT_EQ(sink->getComponent("output").size(), 100u);
+
+    // Further steps must keep behaving safely (cache stays rebuilt/empty).
+    EXPECT_NO_THROW(sink->step(0.0, 1.0));
+}
+
+TEST(ChangeDimensions, ConnectedSourceResizeBackToMatchingSizeStaysConnected)
+{
+    // Sanity check for the "false positive" direction: if the source is
+    // resized (forcing a cache rebuild) but ends up the same size as before,
+    // the connection must remain intact and keep delivering values.
+    const auto source = makeGaussStimulus(100);
+    const auto sink = makeNeuralField(100);
+    sink->addInput(source, "output");
+
+    source->init();
+    sink->init();
+
+    EXPECT_NO_THROW(source->step(0.0, 1.0));
+    EXPECT_NO_THROW(sink->step(0.0, 1.0));
+
+    // Resize down and back up to the original size: forces reallocation(s)
+    // of "output" without changing the final size, exercising the
+    // cache-rebuild path with a still-compatible connection.
+    source->changeDimensions(dim(50));
+    source->changeDimensions(dim(100));
+
+    EXPECT_NO_THROW(source->step(0.0, 1.0));
+    EXPECT_NO_THROW(sink->step(0.0, 1.0));
+    EXPECT_TRUE(sink->hasInput());
+    EXPECT_TRUE(source->hasOutput());
+}


### PR DESCRIPTION
Closes #40.

## Problem
`Element::buildInputCache()` cached a raw `const double* + size` snapshot of each connected source's component. `changeDimensions()` on a **source** reallocates its component vectors but never touches the **downstream** consumer's cache, so `updateInput()` kept dereferencing a stale/dangling pointer with a mismatched size → out-of-bounds reads/writes, silent corruption or crash.

## Fix (`element.h`, `element.cpp`)
- `cachedInputs` now stores `const std::vector<double>*` — a pointer to the source's **vector object** inside its owner's `components` map, not a `.data()`/`.size()` snapshot. An `unordered_map` value's address is stable across `assign`/resize (only the internal buffer reallocates), so re-reading `->size()`/data from it each step always sees the source's **current** state and can never dangle.
- `updateInput()` re-derives each source's live size every call. A source that still fits (`srcVec.size() <= inputSize`) is accumulated safely — this preserves the legitimate case where an element keeps an `"input"` buffer larger than the source (e.g. a circular `GaussKernel` pads for convolution). A source that grew **past** `inputSize` is skipped and flagged.
- New `severIncompatibleInputs()`: removes any input whose source no longer fits, logs a WARNING per severed link, erases both sides of the connection, and resets `inputPtr = nullptr` to force a full cache rebuild next call. Writes are therefore only ever `inputPtr[i]` for `i < srcVec.size() <= inputSize` — no OOB is structurally possible.

## Tests (`tests/elements/test_change_dimensions.cpp`)
- `ConnectedSourceResizeIsSafelySevered`: connect sink ← source (both 100), step (cache builds), grow source to 5000 via `changeDimensions()`, step again → no throw, connection severed, sink buffers stay 100.
- `ConnectedSourceResizeBackToMatchingSizeStaysConnected`: down-then-back-to-matching stays connected.

**Confirmed the test catches the bug:** stashing the fix (keeping only the test) and rebuilding reproduces the defect deterministically (`hasInput()` stays `true`); restoring the fix makes it pass with the expected WARNING.

## Verification
Targeted 2/2; full suite **974/974**, no regressions. (Caught + fixed one self-inflicted regression from an initial stricter `!=` check that broke GaussKernel's legitimate padding; relaxed to the bounds-safety `<=` condition.)