### PR TITLE
refactor: clean up lineplot dead code and hardcoded axis indices

### DIFF
--- a/dynamic-neural-field-composer/src/visualization/lineplot.cpp
+++ b/dynamic-neural-field-composer/src/visualization/lineplot.cpp
@@ -181,27 +181,6 @@ namespace dnf_composer
             );
         }
 
-		// --- Custom bold title (above the plot) ---
-		// ImGui::PushFont(g_BoldLargeFont);
-		// ImGui::TextUnformatted(commonParameters.annotations.title.c_str());
-		// ImGui::PopFont();
-		// ImGui::Spacing();
-
-		// // or centered:
-		// ImGui::PushFont(g_BoldLargeFont);
-		// const float textWidth = ImGui::CalcTextSize(commonParameters.annotations.title.c_str()).x;
-		// const float availWidth = ImGui::GetContentRegionAvail().x;
-		// ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (availWidth - textWidth) * 0.5f);
-		// ImGui::TextUnformatted(commonParameters.annotations.title.c_str());
-		// ImGui::PopFont();
-		// ImGui::Spacing();
-
-		// const std::string plotInternalID = "##" + uniquePlotID;
-  //
-  //       if (!ImPlot::BeginPlot(plotInternalID.c_str(), plotSize, flags)) {
-  //           return;
-  //       }
-
 		if (!ImPlot::BeginPlot(uniquePlotID.c_str(), plotSize, flags)) {
 			return;
 		}
@@ -218,10 +197,10 @@ namespace dnf_composer
             if (whereDimensionsChangedByUser) {
                 auto* currentPlot = ImPlot::GetCurrentPlot();
                 if (currentPlot != nullptr) {
-                    currentPlot->Axes[0].Range.Min = commonParameters.dimensions.xMin - safeMargin;
-                    currentPlot->Axes[0].Range.Max = commonParameters.dimensions.xMax + safeMargin;
-                    currentPlot->Axes[3].Range.Min = commonParameters.dimensions.yMin - safeMargin;
-                    currentPlot->Axes[3].Range.Max = commonParameters.dimensions.yMax + safeMargin;
+                    currentPlot->Axes[ImAxis_X1].Range.Min = commonParameters.dimensions.xMin - safeMargin;
+                    currentPlot->Axes[ImAxis_X1].Range.Max = commonParameters.dimensions.xMax + safeMargin;
+                    currentPlot->Axes[ImAxis_Y1].Range.Min = commonParameters.dimensions.yMin - safeMargin;
+                    currentPlot->Axes[ImAxis_Y1].Range.Max = commonParameters.dimensions.yMax + safeMargin;
                 }
             }
         }


### PR DESCRIPTION
Closes #52.

Pure cleanup/readability change to the line-plot renderer — no functional or visual change.

## What
- Removed a ~20-line block of commented-out dead code in `render()` (an unused 'custom bold title' experiment and a stale alternate `ImPlot::BeginPlot` call using a never-used `plotInternalID`).
- Replaced hardcoded raw ImPlot axis indices with named constants: `Axes[0]` → `Axes[ImAxis_X1]`, `Axes[3]` → `Axes[ImAxis_Y1]` (verified against implot.h: `ImAxis_X1==0`, `ImAxis_Y1==3`, so behavior is identical).

Only `src/visualization/lineplot.cpp` changed (+4/-25). `lineplot.h` was inspected — no dead code or hardcoded axis values — left untouched.

## Left intentionally in place (documented for review)
- `#include "application/application.h"` looks unused but is load-bearing: it transitively provides the ImGui/ImPlot headers this file uses directly. Removing it breaks the build.
- The `bool autoFit` local is the standard immediate-mode-UI bind-then-sync pattern, not dead code.
- `getAutoFit()` returning `double` from a `bool` is odd but is a public API signature (out of scope).

## Verification
- Fresh Ninja + MSVC + vcpkg build, clean, no new warnings.
- Full suite: 972/972 pass.