### PR TITLE
refactor: use std::format for log-message string building

### DIFF
--- a/dynamic-neural-field-composer/src/application/application.cpp
+++ b/dynamic-neural-field-composer/src/application/application.cpp
@@ -1,4 +1,5 @@
 ﻿#include <array>
+#include <format>
 #include <utility>
 
 #include "application/application.h"
@@ -94,7 +95,7 @@ namespace dnf_composer
 	void Application::toggleGUI()
 	{
 		guiActive = !guiActive;
-		log(tools::logger::LogLevel::INFO,std::string("GUI is ") + (guiActive ? "enabled." : "disabled."));
+		log(tools::logger::LogLevel::INFO, std::format("GUI is {}", guiActive ? "enabled." : "disabled."));
 	}
 
 	bool Application::hasGUIBeenClosed() const

--- a/dynamic-neural-field-composer/src/dynamic-neural-field-composer-dynamic.cpp
+++ b/dynamic-neural-field-composer/src/dynamic-neural-field-composer-dynamic.cpp
@@ -1,5 +1,7 @@
 ﻿#include "dynamic-neural-field-composer-dynamic.h"
 
+#include <format>
+
 #include "user_interface/control_bar_window.h"
 #include "user_interface/static_layout.h"
 #include "user_interface/status_bar_window.h"
@@ -39,13 +41,13 @@ int main()
 	}
 	catch (const dnf_composer::Exception& ex)
 	{
-		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		const std::string errorMessage = std::format("Exception: {} ErrorCode: {}. ", ex.what(), static_cast<int>(ex.getErrorCode()));
 		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
 		return static_cast<int>(ex.getErrorCode());
 	}
 	catch (const std::exception& ex)
 	{
-		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		log(dnf_composer::tools::logger::LogLevel::FATAL, std::format("Exception caught: {}. ", ex.what()), dnf_composer::tools::logger::LogOutputMode::CONSOLE);
 		return 1;
 	}
 	catch (...)

--- a/dynamic-neural-field-composer/src/dynamic-neural-field-composer-static.cpp
+++ b/dynamic-neural-field-composer/src/dynamic-neural-field-composer-static.cpp
@@ -1,5 +1,7 @@
 ﻿#include "dynamic-neural-field-composer-static.h"
 
+#include <format>
+
 
 
 int main()
@@ -28,13 +30,13 @@ int main()
 	}
 	catch (const dnf_composer::Exception& ex)
 	{
-		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		const std::string errorMessage = std::format("Exception: {} ErrorCode: {}. ", ex.what(), static_cast<int>(ex.getErrorCode()));
 		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
 		return static_cast<int>(ex.getErrorCode());
 	}
 	catch (const std::exception& ex)
 	{
-		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		log(dnf_composer::tools::logger::LogLevel::FATAL, std::format("Exception caught: {}. ", ex.what()), dnf_composer::tools::logger::LogOutputMode::CONSOLE);
 		return 1;
 	}
 	catch (...)

--- a/dynamic-neural-field-composer/src/element_parameters/element_parameters.cpp
+++ b/dynamic-neural-field-composer/src/element_parameters/element_parameters.cpp
@@ -11,8 +11,8 @@ namespace dnf_composer::element
 		}	
 		else if (dimensionality != 1)
 		{
-			const std::string logMessage = "Element dimensionality '" + std::to_string(dimensionality) +
-										"' is invalid. Defaulting to {1D, 100, 1.0}.";
+			const std::string logMessage = std::format("Element dimensionality '{}' is invalid. Defaulting to {{1D, 100, 1.0}}.",
+										dimensionality);
 			log(tools::logger::LogLevel::ERROR, logMessage);
 			this->dimensionality = 1;
 		}

--- a/dynamic-neural-field-composer/src/elements/collapse.cpp
+++ b/dynamic-neural-field-composer/src/elements/collapse.cpp
@@ -1,5 +1,6 @@
 #include "elements/collapse.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -23,10 +24,10 @@
 			                                : parameters.inputDimensions.size_y;
 			if (commonParameters.dimensionParameters.size != keptAxisSize)
 			{
-				log(tools::logger::LogLevel::ERROR, "Collapse '" + this->getUniqueName()
-					+ "': output size (" + std::to_string(commonParameters.dimensionParameters.size)
-					+ ") must equal the kept " + ProjectionAxisToString.at(parameters.keepAxis)
-					+ "-axis size (" + std::to_string(keptAxisSize) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Collapse '{}': output size ({}) must equal the kept {}-axis size ({}).",
+					this->getUniqueName(), commonParameters.dimensionParameters.size,
+					ProjectionAxisToString.at(parameters.keepAxis), keptAxisSize));
 				throw Exception(ErrorCode::ELEM_INVALID_SIZE, this->getUniqueName());
 			}
 
@@ -70,8 +71,8 @@
 			// past the resized "input" buffer. Reject any additional input.
 			if (!inputs.empty())
 			{
-				log(tools::logger::LogLevel::ERROR, "Collapse '" + this->getUniqueName()
-					+ "' already has an input; only one input is allowed.");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Collapse '{}' already has an input; only one input is allowed.", this->getUniqueName()));
 				return;
 			}
 
@@ -80,9 +81,9 @@
 			const auto& srcDims = inputElement->getElementCommonParameters().dimensionParameters;
 			if (srcDims.dimensionality != 2)
 			{
-				log(tools::logger::LogLevel::ERROR, "Collapse '" + this->getUniqueName()
-					+ "': input must be a 2D element (got dimensionality "
-					+ std::to_string(srcDims.dimensionality) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Collapse '{}': input must be a 2D element (got dimensionality {}).",
+					this->getUniqueName(), srcDims.dimensionality));
 				return;
 			}
 
@@ -93,11 +94,10 @@
 			const int keptAxisSize = keepX ? srcDims.size_x : srcDims.size_y;
 			if (commonParameters.dimensionParameters.size != keptAxisSize)
 			{
-				log(tools::logger::LogLevel::ERROR, "Collapse '" + this->getUniqueName()
-					+ "': cannot connect input; output size ("
-					+ std::to_string(commonParameters.dimensionParameters.size)
-					+ ") must equal the source's kept " + ProjectionAxisToString.at(parameters.keepAxis)
-					+ "-axis size (" + std::to_string(keptAxisSize) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Collapse '{}': cannot connect input; output size ({}) must equal the source's kept {}-axis size ({}).",
+					this->getUniqueName(), commonParameters.dimensionParameters.size,
+					ProjectionAxisToString.at(parameters.keepAxis), keptAxisSize));
 				return;
 			}
 

--- a/dynamic-neural-field-composer/src/elements/element.cpp
+++ b/dynamic-neural-field-composer/src/elements/element.cpp
@@ -1,5 +1,6 @@
 ﻿#include "elements/element.h"
 
+#include <format>
 
 namespace dnf_composer::element
 {
@@ -7,8 +8,7 @@ namespace dnf_composer::element
 	{
 		if(parameters.dimensionParameters.size <= 0)
 		{
-			const std::string logMessage = "Element '" + parameters.identifiers.uniqueName +
-			                               "' has an invalid size.";
+			const std::string logMessage = std::format("Element '{}' has an invalid size.", parameters.identifiers.uniqueName);
 			log(tools::logger::LogLevel::ERROR, logMessage);
 			return;
 		}
@@ -88,7 +88,7 @@ namespace dnf_composer::element
 		const auto existingInput = inputs.find(inputElement);
 		if (existingInput != inputs.end())
 		{
-			const std::string logMessage = "Input '" + inputElement->getUniqueName() + "' already exists. ";
+			const std::string logMessage = std::format("Input '{}' already exists. ", inputElement->getUniqueName());
 			log(tools::logger::LogLevel::ERROR, logMessage);
 			return;
 		}
@@ -97,8 +97,8 @@ namespace dnf_composer::element
 		{
 			if (inputElement->getComponentPtr("output")->size() != this->getSize())
 			{
-				const std::string logMessage = "Input '" + inputElement->getUniqueName() + "' has a different size than '"
-				                               + this->getUniqueName() + "'.";
+				const std::string logMessage = std::format("Input '{}' has a different size than '{}'.",
+				                               inputElement->getUniqueName(), this->getUniqueName());
 				log(tools::logger::LogLevel::ERROR, logMessage);
 				return;
 			}
@@ -108,7 +108,7 @@ namespace dnf_composer::element
 		inputElement->outputs[this->shared_from_this()] = inputComponent;
 		inputPtr = nullptr;
 
-		const std::string logMessage = "Input '" + inputElement->getUniqueName() +"' added successfully to '" +  this->getUniqueName() + ".";
+		const std::string logMessage = std::format("Input '{}' added successfully to '{}.", inputElement->getUniqueName(), this->getUniqueName());
 		log(tools::logger::LogLevel::INFO, logMessage);
 	}
 
@@ -119,8 +119,8 @@ namespace dnf_composer::element
 			if (key->commonParameters.identifiers.uniqueName == inputElementId) {
 				inputs.erase(key);
 				inputPtr = nullptr;
-				log(tools::logger::LogLevel::INFO, "Input '" + inputElementId + "' removed successfully from '"
-				                                   + this->getUniqueName() + ". ");
+				log(tools::logger::LogLevel::INFO, std::format("Input '{}' removed successfully from '{}. ",
+				                                   inputElementId, this->getUniqueName()));
 				return;
 			}
 		}
@@ -133,8 +133,8 @@ namespace dnf_composer::element
 			if (key->commonParameters.identifiers.uniqueIdentifier == uniqueId) {
 				inputs.erase(key);
 				inputPtr = nullptr;
-				log(tools::logger::LogLevel::INFO, "Input '" + std::to_string(uniqueId) + "' removed successfully from '"
-				                                   + this->getUniqueName() + ".");
+				log(tools::logger::LogLevel::INFO, std::format("Input '{}' removed successfully from '{}.",
+				                                   uniqueId, this->getUniqueName()));
 				return;
 			}
 		}
@@ -276,8 +276,8 @@ namespace dnf_composer::element
 		{
 			if (key->commonParameters.identifiers.uniqueIdentifier == uniqueId) {
 				outputs.erase(key);
-				log(tools::logger::LogLevel::INFO, "Output '" + std::to_string(uniqueId) + "' removed successfully from '"
-				                                   + this->getUniqueName() + ".");
+				log(tools::logger::LogLevel::INFO, std::format("Output '{}' removed successfully from '{}.",
+				                                   uniqueId, this->getUniqueName()));
 				return;
 			}
 		}
@@ -289,8 +289,8 @@ namespace dnf_composer::element
 		{
 			if (key->commonParameters.identifiers.uniqueName == outputElementId) {
 				outputs.erase(key);
-				log(tools::logger::LogLevel::INFO, "Output '" + outputElementId + "' removed successfully from '"
-				                                   + this->getUniqueName() + ".");
+				log(tools::logger::LogLevel::INFO, std::format("Output '{}' removed successfully from '{}.",
+				                                   outputElementId, this->getUniqueName()));
 				return;
 			}
 		}

--- a/dynamic-neural-field-composer/src/elements/expand.cpp
+++ b/dynamic-neural-field-composer/src/elements/expand.cpp
@@ -1,5 +1,6 @@
 #include "elements/expand.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -22,10 +23,10 @@
 			                                   : commonParameters.dimensionParameters.size_y;
 			if (parameters.inputDimensions.size != profileAxisSize)
 			{
-				log(tools::logger::LogLevel::ERROR, "Expand '" + this->getUniqueName()
-					+ "': input size (" + std::to_string(parameters.inputDimensions.size)
-					+ ") must equal the output's " + ProjectionAxisToString.at(parameters.broadcastProfileAxis)
-					+ "-axis size (" + std::to_string(profileAxisSize) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Expand '{}': input size ({}) must equal the output's {}-axis size ({}).",
+					this->getUniqueName(), parameters.inputDimensions.size,
+					ProjectionAxisToString.at(parameters.broadcastProfileAxis), profileAxisSize));
 				throw Exception(ErrorCode::ELEM_INVALID_SIZE, this->getUniqueName());
 			}
 
@@ -61,8 +62,8 @@
 			// past the resized "input" buffer. Reject any additional input.
 			if (!inputs.empty())
 			{
-				log(tools::logger::LogLevel::ERROR, "Expand '" + this->getUniqueName()
-					+ "' already has an input; only one input is allowed.");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Expand '{}' already has an input; only one input is allowed.", this->getUniqueName()));
 				return;
 			}
 
@@ -71,9 +72,9 @@
 			const auto& srcDims = inputElement->getElementCommonParameters().dimensionParameters;
 			if (srcDims.dimensionality != 1)
 			{
-				log(tools::logger::LogLevel::ERROR, "Expand '" + this->getUniqueName()
-					+ "': input must be a 1D element (got dimensionality "
-					+ std::to_string(srcDims.dimensionality) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Expand '{}': input must be a 1D element (got dimensionality {}).",
+					this->getUniqueName(), srcDims.dimensionality));
 				return;
 			}
 
@@ -84,10 +85,10 @@
 			                                   : commonParameters.dimensionParameters.size_y;
 			if (srcDims.size != profileAxisSize)
 			{
-				log(tools::logger::LogLevel::ERROR, "Expand '" + this->getUniqueName()
-					+ "': cannot connect input; source size (" + std::to_string(srcDims.size)
-					+ ") must equal the output's " + ProjectionAxisToString.at(parameters.broadcastProfileAxis)
-					+ "-axis size (" + std::to_string(profileAxisSize) + ").");
+				log(tools::logger::LogLevel::ERROR, std::format(
+					"Expand '{}': cannot connect input; source size ({}) must equal the output's {}-axis size ({}).",
+					this->getUniqueName(), srcDims.size,
+					ProjectionAxisToString.at(parameters.broadcastProfileAxis), profileAxisSize));
 				return;
 			}
 

--- a/dynamic-neural-field-composer/src/elements/field_coupling.cpp
+++ b/dynamic-neural-field-composer/src/elements/field_coupling.cpp
@@ -1,6 +1,7 @@
 ﻿#include "elements/field_coupling.h"
 #include "tools/utils.h"
 #include <filesystem>
+#include <format>
 
 
 	namespace dnf_composer::element
@@ -131,16 +132,18 @@
 		{
 			if (inputs.size() != 1)
 			{
-				const std::string logMessage = "Incorrect number of inputs for field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be 1, is " + std::to_string(inputs.size()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect number of inputs for field coupling '{}'. Should be 1, is {}.",
+					commonParameters.identifiers.uniqueName, inputs.size());
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}
 
 			if (inputs.begin()->first->getLabel() != ElementLabel::NEURAL_FIELD)
 			{
-				const std::string logMessage = "Incorrect input type for field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be a neural field, is " + ElementLabelToString.at(inputs.begin()->first->getLabel()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect input type for field coupling '{}'. Should be a neural field, is {}.",
+					commonParameters.identifiers.uniqueName, ElementLabelToString.at(inputs.begin()->first->getLabel()));
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}	
@@ -152,16 +155,18 @@
 		{
 			if (outputs.size() != 1)
 			{
-				const std::string logMessage = "Incorrect number of outputs for field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be 1, is " + std::to_string(outputs.size()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect number of outputs for field coupling '{}'. Should be 1, is {}.",
+					commonParameters.identifiers.uniqueName, outputs.size());
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}
 
 			if (outputs.begin()->first->getLabel() != ElementLabel::NEURAL_FIELD)
 			{
-				const std::string logMessage = "Incorrect output type for field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be a neural field, is " + ElementLabelToString.at(outputs.begin()->first->getLabel()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect output type for field coupling '{}'. Should be a neural field, is {}.",
+					commonParameters.identifiers.uniqueName, ElementLabelToString.at(outputs.begin()->first->getLabel()));
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}
@@ -216,22 +221,19 @@
 				// Check if the total number of weights matches the expected size
 				if (weights.size() != expectedSize)
 				{
-					log(tools::logger::LogLevel::ERROR,
-						"Weight matrix read from file has a different size than expected! "
-						"Expected: " + std::to_string(expectedSize) +
-						", Got: " + std::to_string(weights.size()));
+					log(tools::logger::LogLevel::ERROR, std::format(
+						"Weight matrix read from file has a different size than expected! Expected: {}, Got: {}",
+						expectedSize, weights.size()));
 					return;
 				}
 
 				components["weights"] = weights;
 
-				const std::string message = "Weights '" + this->getUniqueName() + "' read successfully from: " +
-					filename + ".";
+				const std::string message = std::format("Weights '{}' read successfully from: {}.", this->getUniqueName(), filename);
 				log(tools::logger::LogLevel::INFO, message);
 			}
 			else {
-				const std::string message = "Failed to read weights '" + this->getUniqueName() + "' from: " +
-					filename + ".";
+				const std::string message = std::format("Failed to read weights '{}' from: {}.", this->getUniqueName(), filename);
 				log(tools::logger::LogLevel::ERROR, message);
 			}
 		}
@@ -245,9 +247,9 @@
 			}
 			else
 			{
-				log(tools::logger::LogLevel::INFO,
-					"No weights file found for '" + commonParameters.identifiers.uniqueName
-					+ "' at: " + filename + ". Starting with zero weights.");
+				log(tools::logger::LogLevel::INFO, std::format(
+					"No weights file found for '{}' at: {}. Starting with zero weights.",
+					commonParameters.identifiers.uniqueName, filename));
 			}
 		}
 
@@ -273,11 +275,11 @@
 
 				file.close();
 
-				const std::string message = "Saved weights '" + this->getUniqueName() + "' to: " + filename + ".";
+				const std::string message = std::format("Saved weights '{}' to: {}.", this->getUniqueName(), filename);
 				log(tools::logger::LogLevel::INFO, message);
 			}
 			else {
-				const std::string message = "Failed to save weights '" + this->getUniqueName() + "' to: " + filename + ".";
+				const std::string message = std::format("Failed to save weights '{}' to: {}.", this->getUniqueName(), filename);
 				log(tools::logger::LogLevel::ERROR, message);
 			}
 		}
@@ -291,8 +293,8 @@
 		{
 			if (!input)
 			{
-				const std::string logMessage = "Field coupling '" + commonParameters.identifiers.uniqueName +
-					"' has no input field. Learning is disabled.";
+				const std::string logMessage = std::format(
+					"Field coupling '{}' has no input field. Learning is disabled.", commonParameters.identifiers.uniqueName);
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				parameters.isLearningActive = false;
 				return false;
@@ -300,8 +302,8 @@
 
 			if (!output)
 			{
-				const std::string logMessage = "Field coupling '" + commonParameters.identifiers.uniqueName +
-					"' has no output field. Learning is disabled.";
+				const std::string logMessage = std::format(
+					"Field coupling '{}' has no output field. Learning is disabled.", commonParameters.identifiers.uniqueName);
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				parameters.isLearningActive = false;
 				return false;

--- a/dynamic-neural-field-composer/src/elements/gauss_field_coupling.cpp
+++ b/dynamic-neural-field-composer/src/elements/gauss_field_coupling.cpp
@@ -1,4 +1,5 @@
-﻿#include <utility>
+﻿#include <format>
+#include <utility>
 
 #include "elements/gauss_field_coupling.h"
 
@@ -133,16 +134,18 @@
 		{
 			if (inputs.size() != 1)
 			{
-				const std::string logMessage = "Incorrect number of inputs for gauss field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be 1, is " + std::to_string(inputs.size()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect number of inputs for gauss field coupling '{}'. Should be 1, is {}.",
+					commonParameters.identifiers.uniqueName, inputs.size());
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}
 
 			if (inputs.begin()->first->getLabel() != ElementLabel::NEURAL_FIELD)
 			{
-				const std::string logMessage = "Incorrect input type for field coupling '"
-					+ commonParameters.identifiers.uniqueName + "'. Should be a neural field, is " + ElementLabelToString.at(inputs.begin()->first->getLabel()) + ".";
+				const std::string logMessage = std::format(
+					"Incorrect input type for field coupling '{}'. Should be a neural field, is {}.",
+					commonParameters.identifiers.uniqueName, ElementLabelToString.at(inputs.begin()->first->getLabel()));
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}

--- a/dynamic-neural-field-composer/src/elements/gauss_stimulus.cpp
+++ b/dynamic-neural-field-composer/src/elements/gauss_stimulus.cpp
@@ -1,5 +1,6 @@
 ﻿#include "elements/gauss_stimulus.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -41,9 +42,9 @@
 }
 				} else
 				{
-					const std::string message = "Tried to initialize a normalized Gaussian stimulus '"
-						+ this->getUniqueName() + "'. With the sum of the output vector equal "
-								"to zero that is impossible! ";
+					const std::string message = std::format(
+						"Tried to initialize a normalized Gaussian stimulus '{}'. With the sum of the output vector equal to zero that is impossible! ",
+						this->getUniqueName());
 					log(tools::logger::LogLevel::ERROR, message);
 				}
 			}

--- a/dynamic-neural-field-composer/src/elements/gauss_stimulus_2d.cpp
+++ b/dynamic-neural-field-composer/src/elements/gauss_stimulus_2d.cpp
@@ -4,6 +4,7 @@
 
 #include "elements/gauss_stimulus_2d.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -68,9 +69,9 @@
 				}
 				else
 				{
-					const std::string message = "Tried to initialize a normalized Gaussian stimulus 2D '"
-						+ getUniqueName() + "'. With the sum of the output vector equal "
-						"to zero that is impossible! ";
+					const std::string message = std::format(
+						"Tried to initialize a normalized Gaussian stimulus 2D '{}'. With the sum of the output vector equal to zero that is impossible! ",
+						getUniqueName());
 					log(tools::logger::LogLevel::ERROR, message);
 				}
 			}

--- a/dynamic-neural-field-composer/src/elements/resize.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize.cpp
@@ -1,5 +1,6 @@
 #include "elements/resize.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -53,8 +54,8 @@
 			// past the resized "input" buffer. Reject any additional input.
 			if (!inputs.empty())
 			{
-				log(tools::logger::LogLevel::ERROR, "Resize '" + this->getUniqueName()
-					+ "' already has an input; only one input is allowed.");
+				log(tools::logger::LogLevel::ERROR, std::format("Resize '{}' already has an input; only one input is allowed.",
+					this->getUniqueName()));
 				return;
 			}
 

--- a/dynamic-neural-field-composer/src/elements/resize_2d.cpp
+++ b/dynamic-neural-field-composer/src/elements/resize_2d.cpp
@@ -1,5 +1,6 @@
 #include "elements/resize_2d.h"
 
+#include <format>
 
 	namespace dnf_composer::element
 	{
@@ -101,8 +102,8 @@
 			// past the resized "input" buffer. Reject any additional input.
 			if (!inputs.empty())
 			{
-				log(tools::logger::LogLevel::ERROR, "Resize2D '" + this->getUniqueName()
-					+ "' already has an input; only one input is allowed.");
+				log(tools::logger::LogLevel::ERROR, std::format("Resize2D '{}' already has an input; only one input is allowed.",
+					this->getUniqueName()));
 				return;
 			}
 

--- a/dynamic-neural-field-composer/src/elements/timed_gauss_stimulus.cpp
+++ b/dynamic-neural-field-composer/src/elements/timed_gauss_stimulus.cpp
@@ -4,6 +4,8 @@
 
 #include "elements/timed_gauss_stimulus.h"
 
+#include <format>
+
 namespace dnf_composer::element
 {
 	TimedGaussStimulus::TimedGaussStimulus(const ElementCommonParameters& elementCommonParameters,
@@ -47,8 +49,8 @@ namespace dnf_composer::element
 }
 			} else
 			{
-				const std::string message = "Tried to normalize TimedGaussStimulus '"
-					+ getUniqueName() + "' but sum of Gaussian is zero.";
+				const std::string message = std::format("Tried to normalize TimedGaussStimulus '{}' but sum of Gaussian is zero.",
+					getUniqueName());
 				log(tools::logger::LogLevel::ERROR, message);
 			}
 		}

--- a/dynamic-neural-field-composer/src/elements/timed_gauss_stimulus_2d.cpp
+++ b/dynamic-neural-field-composer/src/elements/timed_gauss_stimulus_2d.cpp
@@ -4,6 +4,8 @@
 
 #include "elements/timed_gauss_stimulus_2d.h"
 
+#include <format>
+
 namespace dnf_composer::element
 {
 	TimedGaussStimulus2D::TimedGaussStimulus2D(const ElementCommonParameters& elementCommonParameters,
@@ -72,8 +74,8 @@ namespace dnf_composer::element
 			}
 			else
 			{
-				const std::string message = "Tried to normalize TimedGaussStimulus2D '"
-					+ getUniqueName() + "' but sum of Gaussian is zero.";
+				const std::string message = std::format("Tried to normalize TimedGaussStimulus2D '{}' but sum of Gaussian is zero.",
+					getUniqueName());
 				log(tools::logger::LogLevel::ERROR, message);
 			}
 		}

--- a/dynamic-neural-field-composer/src/simulation/simulation.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation.cpp
@@ -1,6 +1,7 @@
 ﻿#include "simulation/simulation.h"
 #include "simulation/simulation_file_manager.h"
 #include "tools/utils.h"
+#include <format>
 
 
 
@@ -26,11 +27,9 @@ namespace dnf_composer
 		initialized = false;
 		paused = false;
 		elements = {};
-		std::ostringstream oss;
-		oss << "Simulation '" << uniqueIdentifier << "' created. "
-			<< "With parameters [dt:" << std::fixed << std::setprecision(2) << deltaT
-			<< "s, t0:" << tZero << "s].";
-		tools::logger::log(tools::logger::LogLevel::INFO, oss.str());
+		tools::logger::log(tools::logger::LogLevel::INFO,
+			std::format("Simulation '{}' created. With parameters [dt:{:.2f}s, t0:{:.2f}s].",
+				uniqueIdentifier, deltaT, tZero));
 	}
 
 	Simulation::Simulation(const Simulation& other)
@@ -288,7 +287,7 @@ namespace dnf_composer
 		for (const auto& existingElement : elements) {
 			if (existingElement->getUniqueName() == newElementName)
 			{
-				const std::string logMessage = "An element with the same unique name already exists '" + newElementName + "'! New element was not added.";
+				const std::string logMessage = std::format("An element with the same unique name already exists '{}'! New element was not added.", newElementName);
 				log(tools::logger::LogLevel::WARNING, logMessage);
 				return;
 			}
@@ -297,7 +296,7 @@ namespace dnf_composer
 		elements.emplace_back(element);
 		element->init();
 
-		const std::string logMessage = "Element '" + newElementName + "' was added to the simulation.";
+		const std::string logMessage = std::format("Element '{}' was added to the simulation.", newElementName);
 		log(tools::logger::LogLevel::INFO, logMessage);
 	}
 
@@ -313,12 +312,12 @@ namespace dnf_composer
 			if (elements[i]->getUniqueName() == elementId)
 			{
 				elements.erase(elements.begin() + i);
-				const std::string logMessage = "Element '" + elementId + "' was removed from the simulation.";
+				const std::string logMessage = std::format("Element '{}' was removed from the simulation.", elementId);
 				log(tools::logger::LogLevel::INFO, logMessage);
 				return;
 			}
 		}
-		const std::string logMessage = "Element '" + elementId + "' was not found and consequently not removed from the simulation.";
+		const std::string logMessage = std::format("Element '{}' was not found and consequently not removed from the simulation.", elementId);
 		log(tools::logger::LogLevel::FATAL, logMessage);
 	}
 
@@ -332,7 +331,7 @@ namespace dnf_composer
 			{
 				element = newElement;
 				element->init();
-				const std::string logMessage = "Element '" + idOfElementToReset + "' was reset in the simulation.";
+				const std::string logMessage = std::format("Element '{}' was reset in the simulation.", idOfElementToReset);
 				log(tools::logger::LogLevel::INFO, logMessage);
 				elementFound = true;
 				break;
@@ -341,7 +340,7 @@ namespace dnf_composer
 
 		if (!elementFound)
 		{
-			const std::string logMessage = "Element '" + idOfElementToReset + "' was not found and consequently not reset.";
+			const std::string logMessage = std::format("Element '{}' was not found and consequently not reset.", idOfElementToReset);
 			log(tools::logger::LogLevel::FATAL, logMessage);
 		}
 	}
@@ -354,7 +353,7 @@ namespace dnf_composer
 		element->removeOutputs();
 		element->changeDimensions(newDimensions);
 
-		const std::string logMessage = "Element '" + elementId + "' resized to " + newDimensions.toString() + ".";
+		const std::string logMessage = std::format("Element '{}' resized to {}.", elementId, newDimensions.toString());
 		log(tools::logger::LogLevel::INFO, logMessage);
 	}
 
@@ -366,16 +365,16 @@ namespace dnf_composer
 		const auto elem = getElement(oldName);
 		if (!elem)
 		{
-			log(tools::logger::LogLevel::WARNING, "Element '" + oldName + "' was not found and consequently not renamed.");
+			log(tools::logger::LogLevel::WARNING, std::format("Element '{}' was not found and consequently not renamed.", oldName));
 			return;
 		}
 		if (getElement(newName))
 		{
-			log(tools::logger::LogLevel::WARNING, "Element '" + newName + "' already exists; '" + oldName + "' was not renamed.");
+			log(tools::logger::LogLevel::WARNING, std::format("Element '{}' already exists; '{}' was not renamed.", newName, oldName));
 			return;
 		}
 		elem->setUniqueName(newName);
-		log(tools::logger::LogLevel::INFO, "Element '" + oldName + "' renamed to '" + newName + "'.");
+		log(tools::logger::LogLevel::INFO, std::format("Element '{}' renamed to '{}'.", oldName, newName));
 	}
 
 	void Simulation::createInteraction(const std::string& stimulusElementId,
@@ -386,21 +385,21 @@ namespace dnf_composer
 
 		if (!stimulusElement)
 		{
-			const std::string logMessage = "Element '" + stimulusElementId + "' was not found and consequently no interaction was created.";
+			const std::string logMessage = std::format("Element '{}' was not found and consequently no interaction was created.", stimulusElementId);
 			log(tools::logger::LogLevel::FATAL, logMessage);
 			return;
 		}
 
 		if (!receivingElement)
 		{
-			const std::string logMessage = "Element '" + receivingElementId + "' was not found and consequently no interaction was created.";
+			const std::string logMessage = std::format("Element '{}' was not found and consequently no interaction was created.", receivingElementId);
 			log(tools::logger::LogLevel::FATAL, logMessage);
 			return;
 		}
 
 		receivingElement->addInput(stimulusElement, stimulusComponent);
 
-		const std::string logMessage = "Interaction created: " + stimulusElementId + " -> " + receivingElementId + '.';
+		const std::string logMessage = std::format("Interaction created: {} -> {}.", stimulusElementId, receivingElementId);
 		log(tools::logger::LogLevel::INFO, logMessage);
 
 	}
@@ -455,7 +454,7 @@ namespace dnf_composer
 		const std::shared_ptr<element::Element> foundElement = getElement(id);
 		if (!foundElement)
 		{
-			log(tools::logger::LogLevel::FATAL, "Element '" + id + "' was not found and consequently no component was returned.");
+			log(tools::logger::LogLevel::FATAL, std::format("Element '{}' was not found and consequently no component was returned.", id));
 			return {};
 		}
 		return foundElement->getComponent(componentName);
@@ -466,7 +465,7 @@ namespace dnf_composer
 		const std::shared_ptr<element::Element> foundElement = getElement(id);
 		if (!foundElement)
 		{
-			log(tools::logger::LogLevel::FATAL, "Element '" + id + "' was not found and consequently no component was returned.");
+			log(tools::logger::LogLevel::FATAL, std::format("Element '{}' was not found and consequently no component was returned.", id));
 			return nullptr;
 		}
 		return foundElement->getComponentPtr(componentName);

--- a/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_file_manager.cpp
@@ -1,5 +1,6 @@
 #include "simulation/simulation_file_manager.h"
 
+#include <format>
 #include <unordered_set>
 
 
@@ -44,10 +45,10 @@ namespace dnf_composer
         std::ofstream file(path);
         if (file.is_open()) {
             file << root.dump(4);
-            log(tools::logger::INFO, "Simulation saved to: " + path);
+            log(tools::logger::INFO, std::format("Simulation saved to: {}", path));
         }
         else {
-            log(tools::logger::ERROR, "Unable to open file to save simulation: " + path);
+            log(tools::logger::ERROR, std::format("Unable to open file to save simulation: {}", path));
         }
 	}
 
@@ -55,7 +56,7 @@ namespace dnf_composer
     {
         std::ifstream file(filePath);
         if (!file.is_open()) {
-            log(tools::logger::ERROR, "Unable to open file to load simulation: " + filePath + ".");
+            log(tools::logger::ERROR, std::format("Unable to open file to load simulation: {}.", filePath));
             return;
         }
 
@@ -64,7 +65,7 @@ namespace dnf_composer
             file >> root;
         }
         catch (const std::exception& e) {
-            log(tools::logger::ERROR, "Error reading JSON file: " + std::string(e.what()));
+            log(tools::logger::ERROR, std::format("Error reading JSON file: {}", e.what()));
             return;
         }
 
@@ -80,7 +81,7 @@ namespace dnf_composer
             const json& elems = root.contains("elements") ? root["elements"] : json::array();
             if (!elems.is_array())
             {
-                log(tools::logger::ERROR, "Invalid simulation file: \"elements\" is not an array: " + filePath);
+                log(tools::logger::ERROR, std::format("Invalid simulation file: \"elements\" is not an array: {}", filePath));
                 return;
             }
             elementsJson = elems;
@@ -88,7 +89,7 @@ namespace dnf_composer
             if (root.contains("identifier") && root["identifier"].is_string()) {
                 simulation->setUniqueIdentifier(root["identifier"].get<std::string>());
             } else if (root.contains("identifier")) {
-                log(tools::logger::ERROR, "Invalid simulation file: \"identifier\" is not a string: " + filePath);
+                log(tools::logger::ERROR, std::format("Invalid simulation file: \"identifier\" is not a string: {}", filePath));
 }
 
             if (root.contains("deltaT") && root["deltaT"].is_number())
@@ -97,20 +98,20 @@ namespace dnf_composer
                 if (std::isfinite(dt) && dt > 0.0) {
                     simulation->setDeltaT(dt);
                 } else {
-                    log(tools::logger::ERROR, "Invalid simulation file: \"deltaT\" is not a valid positive number: " + filePath);
+                    log(tools::logger::ERROR, std::format("Invalid simulation file: \"deltaT\" is not a valid positive number: {}", filePath));
 }
             }
             else if (root.contains("deltaT")) {
-                log(tools::logger::ERROR, "Invalid simulation file: \"deltaT\" is not a number: " + filePath);
+                log(tools::logger::ERROR, std::format("Invalid simulation file: \"deltaT\" is not a number: {}", filePath));
 }
         }
         else
         {
-            log(tools::logger::ERROR, "Invalid simulation file: unexpected JSON root type: " + filePath);
+            log(tools::logger::ERROR, std::format("Invalid simulation file: unexpected JSON root type: {}", filePath));
             return;
         }
 
-        log(tools::logger::INFO, "Simulation loaded from: " + filePath);
+        log(tools::logger::INFO, std::format("Simulation loaded from: {}", filePath));
         jsonToElements(elementsJson);
 
         // Point FieldCoupling elements to their weights in the same directory as the JSON file.
@@ -557,8 +558,7 @@ namespace dnf_composer
 	        // (and their interactions in the second pass) with a clear error.
 	        if (!seenNames.insert(uniqueName).second)
 	        {
-	            log(tools::logger::LogLevel::ERROR, "Duplicate element name '" + uniqueName
-	                + "' in file - skipping this element.");
+	            log(tools::logger::LogLevel::ERROR, std::format("Duplicate element name '{}' in file - skipping this element.", uniqueName));
 	            continue;
 	        }
 
@@ -1084,11 +1084,8 @@ namespace dnf_composer
                     // Wiring to a missing element would corrupt the loaded graph.
                     if (!simulation->getElement(keyUniqueName) || !simulation->getElement(uniqueName))
                     {
-                        std::string message = "Skipping interaction '";
-                        message += keyUniqueName;
-                        message += "' -> '";
-                        message += uniqueName;
-                        message += "': one or both elements were not loaded.";
+                        const std::string message = std::format("Skipping interaction '{}' -> '{}': one or both elements were not loaded.",
+                            keyUniqueName, uniqueName);
                         log(tools::logger::WARNING, message);
                         continue;
                     }

--- a/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation_recorder.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <chrono>
+#include <format>
 #include <ranges>
 #include <sstream>
 #include <iomanip>
@@ -68,7 +69,7 @@ namespace dnf_composer
 		if (isRecording(elementId, componentName))
 		{
 			tools::logger::log(tools::logger::LogLevel::WARNING,
-				"Recording already active for '" + elementId + "' / '" + componentName + "'.");
+				std::format("Recording already active for '{}' / '{}'.", elementId, componentName));
 			return;
 		}
 
@@ -89,12 +90,12 @@ namespace dnf_composer
 		if (!session.file.is_open())
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
-				"Failed to open recording file: " + filename);
+				std::format("Failed to open recording file: {}", filename));
 			return;
 		}
 
 		tools::logger::log(tools::logger::LogLevel::INFO,
-			"Recording started: " + filename);
+			std::format("Recording started: {}", filename));
 
 		sessions.push_back(std::move(session));
 	}
@@ -116,7 +117,7 @@ namespace dnf_composer
 }
 
 		tools::logger::log(tools::logger::LogLevel::INFO,
-			"Recording stopped for '" + elementId + "' / '" + componentName + "'.");
+			std::format("Recording stopped for '{}' / '{}'.", elementId, componentName));
 
 		sessions.erase(it);
 	}
@@ -150,7 +151,7 @@ namespace dnf_composer
 			if (!element)
 			{
 				tools::logger::log(tools::logger::LogLevel::WARNING,
-					"Stopping recording for '" + s.elementId + "': element no longer exists.");
+					std::format("Stopping recording for '{}': element no longer exists.", s.elementId));
 				toStop.push_back(i);
 				continue;
 			}
@@ -159,7 +160,7 @@ namespace dnf_composer
 			if (component == nullptr)
 			{
 				tools::logger::log(tools::logger::LogLevel::WARNING,
-					"Stopping recording for '" + s.elementId + "' / '" + s.componentName + "': component unavailable.");
+					std::format("Stopping recording for '{}' / '{}': component unavailable.", s.elementId, s.componentName));
 				toStop.push_back(i);
 				continue;
 			}
@@ -201,7 +202,7 @@ namespace dnf_composer
 		if (!element)
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
-				"Snapshot failed: element '" + elementId + "' not found.");
+				std::format("Snapshot failed: element '{}' not found.", elementId));
 			return;
 		}
 
@@ -209,7 +210,7 @@ namespace dnf_composer
 		if (component == nullptr)
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
-				"Snapshot failed: component '" + componentName + "' not found on '" + elementId + "'.");
+				std::format("Snapshot failed: component '{}' not found on '{}'.", componentName, elementId));
 			return;
 		}
 
@@ -223,7 +224,7 @@ namespace dnf_composer
 		if (!file.is_open())
 		{
 			tools::logger::log(tools::logger::LogLevel::ERROR,
-				"Failed to open snapshot file: " + filename);
+				std::format("Failed to open snapshot file: {}", filename));
 			return;
 		}
 
@@ -235,7 +236,7 @@ namespace dnf_composer
 		writeRow(file, ticks, ms, *component);
 
 		tools::logger::log(tools::logger::LogLevel::INFO,
-			"Snapshot exported to: " + filename);
+			std::format("Snapshot exported to: {}", filename));
 	}
 
 	bool SimulationRecorder::isRecording(const std::string& elementId,

--- a/dynamic-neural-field-composer/src/visualization/visualization.cpp
+++ b/dynamic-neural-field-composer/src/visualization/visualization.cpp
@@ -1,5 +1,7 @@
 ﻿#include "visualization/visualization.h"
 
+#include <format>
+
 namespace dnf_composer
 {
 	extern ImFont* g_BlackLargeFont;
@@ -27,13 +29,13 @@ namespace dnf_composer
 				plots[std::make_shared<Heatmap>()] = {};
 				break;
 		}
-		log(tools::logger::LogLevel::INFO, "Plot " + std::to_string(plots.size() - 1) + " added to visualization.");
+		log(tools::logger::LogLevel::INFO, std::format("Plot {} added to visualization.", plots.size() - 1));
 	}
 
 	void Visualization::plot(const std::vector<std::pair<std::string, std::string>>& data)
 	{
 		plots[std::make_shared<LinePlot>()] = data;
-		log(tools::logger::LogLevel::INFO, "Plot " + std::to_string(plots.size() - 1) + " added to visualization.");
+		log(tools::logger::LogLevel::INFO, std::format("Plot {} added to visualization.", plots.size() - 1));
 	}
 
 	void Visualization::plot(const std::string& name, const std::string& component)
@@ -71,7 +73,7 @@ namespace dnf_composer
 				break;
 			}
 		}
-		log(tools::logger::LogLevel::INFO, "Plot " + std::to_string(plots.size() - 1) + " added to visualization.");
+		log(tools::logger::LogLevel::INFO, std::format("Plot {} added to visualization.", plots.size() - 1));
 	}
 
 	void Visualization::plot(const PlotCommonParameters& parameters, const PlotSpecificParameters& specificParameters, const std::string& name, const std::string& component)
@@ -92,13 +94,13 @@ namespace dnf_composer
 		// Check if the plot was found
 		if (it == plots.end())
 		{
-			log(tools::logger::LogLevel::ERROR, "Plot with ID " + std::to_string(plotId) + " not found.");
+			log(tools::logger::LogLevel::ERROR, std::format("Plot with ID {} not found.", plotId));
 			return;
 		}
 
 		// Add data to the found plot
 		plots[it->first].insert(plots[it->first].end(), data.begin(), data.end());
-		log(tools::logger::LogLevel::INFO, "Data plotted on plot with ID " + std::to_string(plotId) + ".");
+		log(tools::logger::LogLevel::INFO, std::format("Data plotted on plot with ID {}.", plotId));
 	}
 
 	void Visualization::plot(const int plotId, const std::string& name, const std::string& component)
@@ -119,11 +121,11 @@ namespace dnf_composer
 		if (it != plots.end())
 		{
 			plots.erase(it);
-			log(tools::logger::LogLevel::INFO, "Plot with ID " + std::to_string(plotId) + " removed from visualization.");
+			log(tools::logger::LogLevel::INFO, std::format("Plot with ID {} removed from visualization.", plotId));
 		}
 		else
 		{
-			log(tools::logger::LogLevel::ERROR, "Plot with ID " + std::to_string(plotId) + " not found.");
+			log(tools::logger::LogLevel::ERROR, std::format("Plot with ID {} not found.", plotId));
 		}
 	}
 
@@ -145,19 +147,19 @@ namespace dnf_composer
 		// Check if the plot was found
 		if (it == plots.end())
 		{
-			log(tools::logger::LogLevel::ERROR, "Plot with ID " + std::to_string(plotId) + " not found.");
+			log(tools::logger::LogLevel::ERROR, std::format("Plot with ID {} not found.", plotId));
 			return;
 		}
 
 		// Check if the data is in the plot
 		if (std::ranges::find(plots[it->first].begin(), plots[it->first].end(), data) == plots[it->first].end())
 		{
-			log(tools::logger::LogLevel::WARNING, "Data '" + data.first + " - " + data.second + "' not found in plot " + std::to_string(plotId) + ".");
+			log(tools::logger::LogLevel::WARNING, std::format("Data '{} - {}' not found in plot {}.", data.first, data.second, plotId));
 			return;
 		}
 
 		plots[it->first].erase(std::ranges::find(plots[it->first].begin(), plots[it->first].end(), data));
-		log(tools::logger::LogLevel::INFO, "Data '" + data.first + " - " + data.second + "' removed from plot " + std::to_string(plotId) + ".");
+		log(tools::logger::LogLevel::INFO, std::format("Data '{} - {}' removed from plot {}.", data.first, data.second, plotId));
 	}
 
 	// If `plot` is a Heatmap and the data contains a "weights" component,


### PR DESCRIPTION
Closes #61.

Converts log-message string building from `+`/`std::to_string`/`ostringstream` concatenation to `std::format`. `std::format` is already used across the codebase and compiles on all three CI compilers (C++20), so this is a safe, mechanical modernization.

## What
- ~71 logging call-sites converted across 19 `src/` files (element_parameters, visualization, application, simulation, simulation_file_manager, simulation_recorder, ~11 element .cpp files, both library entry points).
- One `ostringstream` with `std::fixed`/`setprecision(2)` folded into `{:.2f}`.
- Literal braces in messages doubled to `{{`/`}}` where needed.

## Scope discipline
- Message text is preserved verbatim — only the construction mechanism changed.
- Only logging strings touched. Non-logging string building (`toString()`, exception messages, GUI titles) is left for #63.
- `lineplot.cpp`/`lineplot.h` untouched (owned by #52 / PR #102).
- Plain literal messages with no interpolation left as-is.

## Verification
- Clean MSVC/Ninja/vcpkg build, zero warnings. (Note: C++20 `std::format` does consteval format-string checking, so a clean compile proves every format string + argument type is valid.)
- Full suite: 972/972 pass.