### PR TITLE
example: add bidirectional and hierarchical architecture examples

### DIFF
--- a/dynamic-neural-field-composer/examples/CMakeLists.txt
+++ b/dynamic-neural-field-composer/examples/CMakeLists.txt
@@ -39,6 +39,8 @@ add_example_executable(benchmark_headless_2d                     benchmark_headl
 #add_example_executable(cpv_1d_test                               cpv_1d_test.cpp)
 #add_example_executable(example_oja_learning             oja_learning.cpp)
 #add_example_executable(example_delta_rule_learning      delta_rule_learning.cpp)
+add_example_executable(example_bidirectional_architecture       bidirectional_architecture.cpp)
+add_example_executable(example_hierarchical_architecture        hierarchical_architecture.cpp)
 
 
 

--- a/dynamic-neural-field-composer/examples/bidirectional_architecture.cpp
+++ b/dynamic-neural-field-composer/examples/bidirectional_architecture.cpp
@@ -1,0 +1,162 @@
+#include "visualization/visualization.h"
+#include "application/application.h"
+#include "elements/element_factory.h"
+#include "user_interface/main_menu_bar.h"
+#include "user_interface/static_layout.h"
+
+// This example demonstrates a bidirectional multi-field architecture:
+// two neural fields ("field A" and "field B") that mutually influence
+// each other through a pair of learned field couplings, one for each
+// direction (A -> B and B -> A). Unlike a purely feedforward chain
+// (see weighted_field_coupling.cpp), activity in either field can be
+// shaped by activity that itself originated in the other field,
+// forming a closed reciprocal loop.
+
+int main()
+{
+	try
+	{
+		using namespace dnf_composer;
+
+		const auto simulation = std::make_shared<Simulation>("Bidirectional architecture (example)",
+			1.0, 0.0, 0.0);
+		const auto visualization = std::make_shared<Visualization>(simulation);
+		const Application app{ simulation, visualization };
+
+		app.addWindow<user_interface::MainMenuBar>();
+		app.addWindow<user_interface::StaticLayoutWindow>(simulation, visualization);
+
+		element::ElementFactory factory;
+
+		// ── Field A ──────────────────────────────────────────────────────────
+		const element::ElementDimensions dimensions_a{200, 1.0};
+		const auto nf_a = factory.createElement(element::ElementLabel::NEURAL_FIELD,
+			element::ElementCommonParameters{element::ElementIdentifiers{"field A"}, dimensions_a},
+			element::NeuralFieldParameters{});
+		const auto mhk_a = factory.createElement(element::MEXICAN_HAT_KERNEL,
+			element::ElementCommonParameters{element::ElementIdentifiers{"kernel field A"}, dimensions_a},
+			element::MexicanHatKernelParameters{});
+		const auto nn_a = factory.createElement(element::NORMAL_NOISE,
+			element::ElementCommonParameters{element::ElementIdentifiers{"normal noise field A"}, dimensions_a},
+			element::NormalNoiseParameters{0.05});
+		const auto gs_a = factory.createElement(element::GAUSS_STIMULUS,
+			element::ElementCommonParameters{element::ElementIdentifiers{"stimulus field A"}, dimensions_a},
+			element::GaussStimulusParameters{5, 15, 30});
+
+		// ── Field B ──────────────────────────────────────────────────────────
+		const element::ElementDimensions dimensions_b{200, 1.0};
+		const auto nf_b = factory.createElement(element::NEURAL_FIELD,
+			element::ElementCommonParameters{element::ElementIdentifiers{"field B"}, dimensions_b},
+			element::NeuralFieldParameters{});
+		const auto gk_b = factory.createElement(element::GAUSS_KERNEL,
+			element::ElementCommonParameters{element::ElementIdentifiers{"kernel field B"}, dimensions_b},
+			element::GaussKernelParameters{});
+		const auto nn_b = factory.createElement(element::NORMAL_NOISE,
+			element::ElementCommonParameters{element::ElementIdentifiers{"normal noise field B"}, dimensions_b},
+			element::NormalNoiseParameters{0.05});
+		const auto gs_b = factory.createElement(element::GAUSS_STIMULUS,
+			element::ElementCommonParameters{element::ElementIdentifiers{"stimulus field B"}, dimensions_b},
+			element::GaussStimulusParameters{5, 15, 120});
+
+		// ── Bidirectional couplings ─────────────────────────────────────────
+		// A -> B: output lives on field B's dimensions, reads from field A.
+		const auto fc_ab = factory.createElement(element::FIELD_COUPLING,
+			element::ElementCommonParameters{element::ElementIdentifiers{"coupling A-to-B"}, dimensions_b},
+			element::FieldCouplingParameters{dimensions_a});
+		// B -> A: output lives on field A's dimensions, reads from field B.
+		const auto fc_ba = factory.createElement(element::FIELD_COUPLING,
+			element::ElementCommonParameters{element::ElementIdentifiers{"coupling B-to-A"}, dimensions_a},
+			element::FieldCouplingParameters{dimensions_b});
+
+		simulation->addElement(nf_a);
+		simulation->addElement(mhk_a);
+		simulation->addElement(nn_a);
+		simulation->addElement(gs_a);
+
+		simulation->addElement(nf_b);
+		simulation->addElement(gk_b);
+		simulation->addElement(nn_b);
+		simulation->addElement(gs_b);
+
+		simulation->addElement(fc_ab);
+		simulation->addElement(fc_ba);
+
+		nf_a->addInput(mhk_a);
+		mhk_a->addInput(nf_a);
+		nf_a->addInput(nn_a);
+		nf_a->addInput(gs_a);
+
+		nf_b->addInput(gk_b);
+		gk_b->addInput(nf_b);
+		nf_b->addInput(nn_b);
+		nf_b->addInput(gs_b);
+
+		// Close the loop: A feeds B, and B feeds back into A.
+		fc_ab->addInput(nf_a);
+		nf_b->addInput(fc_ab);
+
+		fc_ba->addInput(nf_b);
+		nf_a->addInput(fc_ba);
+
+		visualization->plot(
+			PlotCommonParameters{
+			PlotType::LINE_PLOT,
+			PlotDimensions{ 0.0, 200, -20.0, 20, 1.0, 1.0},
+			PlotAnnotations{ "field A dynamics", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { nf_a->getUniqueName(), "activation" }, { nf_a->getUniqueName(), "output" }, { nf_a->getUniqueName(), "input" } });
+
+		visualization->plot(
+			PlotCommonParameters{
+			PlotType::LINE_PLOT,
+			PlotDimensions{ 0.0, 200, -20.0, 20, 1.0, 1.0 },
+			PlotAnnotations{ "field B dynamics", "Spatial location", "Activation" } },
+			LinePlotParameters{},
+			{ {nf_b->getUniqueName(), "activation"}, {nf_b->getUniqueName(), "output"}, {nf_b->getUniqueName(), "input"} });
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::HEATMAP,
+				PlotDimensions{0.0, 200, 0.0, 200, 1.0, 1.0},
+				PlotAnnotations{"A-to-B coupling", "field B spatial location", "field A spatial location"} },
+				HeatmapParameters{},
+			{ {fc_ab->getUniqueName(), "weights"} }
+			);
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::HEATMAP,
+				PlotDimensions{0.0, 200, 0.0, 200, 1.0, 1.0},
+				PlotAnnotations{"B-to-A coupling", "field A spatial location", "field B spatial location"} },
+				HeatmapParameters{},
+			{ {fc_ba->getUniqueName(), "weights"} }
+			);
+
+		app.init();
+
+		while (!app.hasGUIBeenClosed())
+		{
+			app.step();
+		}
+
+		app.close();
+
+		return 0;
+	}
+	catch (const dnf_composer::Exception& ex)
+	{
+		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return static_cast<int>(ex.getErrorCode());
+	}
+	catch (const std::exception& ex)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+	catch (...)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Unknown exception occurred. ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+}

--- a/dynamic-neural-field-composer/examples/hierarchical_architecture.cpp
+++ b/dynamic-neural-field-composer/examples/hierarchical_architecture.cpp
@@ -1,0 +1,205 @@
+#include "visualization/visualization.h"
+#include "application/application.h"
+#include "elements/element_factory.h"
+#include "user_interface/main_menu_bar.h"
+#include "user_interface/static_layout.h"
+
+// This example demonstrates a hierarchical multi-field architecture:
+// three neural fields arranged in levels of increasing abstraction
+// ("low", "mid", "high"). Activity is driven bottom-up through
+// feedforward field couplings (low -> mid -> high), and the highest
+// level in turn sends a top-down field coupling back down to the mid
+// level, modulating it with feedback. Only the lowest level receives
+// an external stimulus; the higher levels are driven entirely through
+// the coupling structure, illustrating how a hierarchy of fields can
+// be composed from the same coupling building blocks used for simple
+// feedforward or bidirectional pairs.
+
+int main()
+{
+	try
+	{
+		using namespace dnf_composer;
+
+		const auto simulation = std::make_shared<Simulation>("Hierarchical architecture (example)",
+			1.0, 0.0, 0.0);
+		const auto visualization = std::make_shared<Visualization>(simulation);
+		const Application app{ simulation, visualization };
+
+		app.addWindow<user_interface::MainMenuBar>();
+		app.addWindow<user_interface::StaticLayoutWindow>(simulation, visualization);
+
+		element::ElementFactory factory;
+
+		// ── Low level: raw, high-resolution sensory field ───────────────────
+		const element::ElementDimensions dimensions_low{280, 1.0};
+		const auto nf_low = factory.createElement(element::ElementLabel::NEURAL_FIELD,
+			element::ElementCommonParameters{element::ElementIdentifiers{"low level field"}, dimensions_low},
+			element::NeuralFieldParameters{});
+		const auto mhk_low = factory.createElement(element::MEXICAN_HAT_KERNEL,
+			element::ElementCommonParameters{element::ElementIdentifiers{"kernel low level field"}, dimensions_low},
+			element::MexicanHatKernelParameters{});
+		const auto nn_low = factory.createElement(element::NORMAL_NOISE,
+			element::ElementCommonParameters{element::ElementIdentifiers{"normal noise low level field"}, dimensions_low},
+			element::NormalNoiseParameters{0.05});
+		const auto gs_low = factory.createElement(element::GAUSS_STIMULUS,
+			element::ElementCommonParameters{element::ElementIdentifiers{"stimulus low level field"}, dimensions_low},
+			element::GaussStimulusParameters{5, 15, 40});
+
+		// ── Mid level: intermediate abstraction, coarser resolution ─────────
+		const element::ElementDimensions dimensions_mid{150, 1.0};
+		const auto nf_mid = factory.createElement(element::NEURAL_FIELD,
+			element::ElementCommonParameters{element::ElementIdentifiers{"mid level field"}, dimensions_mid},
+			element::NeuralFieldParameters{});
+		const auto gk_mid = factory.createElement(element::GAUSS_KERNEL,
+			element::ElementCommonParameters{element::ElementIdentifiers{"kernel mid level field"}, dimensions_mid},
+			element::GaussKernelParameters{});
+		const auto nn_mid = factory.createElement(element::NORMAL_NOISE,
+			element::ElementCommonParameters{element::ElementIdentifiers{"normal noise mid level field"}, dimensions_mid},
+			element::NormalNoiseParameters{0.05});
+
+		// ── High level: most abstract, coarsest resolution ──────────────────
+		const element::ElementDimensions dimensions_high{80, 1.0};
+		const auto nf_high = factory.createElement(element::NEURAL_FIELD,
+			element::ElementCommonParameters{element::ElementIdentifiers{"high level field"}, dimensions_high},
+			element::NeuralFieldParameters{});
+		const auto gk_high = factory.createElement(element::GAUSS_KERNEL,
+			element::ElementCommonParameters{element::ElementIdentifiers{"kernel high level field"}, dimensions_high},
+			element::GaussKernelParameters{});
+		const auto nn_high = factory.createElement(element::NORMAL_NOISE,
+			element::ElementCommonParameters{element::ElementIdentifiers{"normal noise high level field"}, dimensions_high},
+			element::NormalNoiseParameters{0.05});
+
+		// ── Feedforward couplings (bottom-up) ───────────────────────────────
+		const auto fc_low_mid = factory.createElement(element::FIELD_COUPLING,
+			element::ElementCommonParameters{element::ElementIdentifiers{"coupling low-to-mid"}, dimensions_mid},
+			element::FieldCouplingParameters{dimensions_low});
+		const auto fc_mid_high = factory.createElement(element::FIELD_COUPLING,
+			element::ElementCommonParameters{element::ElementIdentifiers{"coupling mid-to-high"}, dimensions_high},
+			element::FieldCouplingParameters{dimensions_mid});
+
+		// ── Feedback coupling (top-down) ─────────────────────────────────────
+		const auto fc_high_mid = factory.createElement(element::FIELD_COUPLING,
+			element::ElementCommonParameters{element::ElementIdentifiers{"coupling high-to-mid (feedback)"}, dimensions_mid},
+			element::FieldCouplingParameters{dimensions_high});
+
+		simulation->addElement(nf_low);
+		simulation->addElement(mhk_low);
+		simulation->addElement(nn_low);
+		simulation->addElement(gs_low);
+
+		simulation->addElement(nf_mid);
+		simulation->addElement(gk_mid);
+		simulation->addElement(nn_mid);
+
+		simulation->addElement(nf_high);
+		simulation->addElement(gk_high);
+		simulation->addElement(nn_high);
+
+		simulation->addElement(fc_low_mid);
+		simulation->addElement(fc_mid_high);
+		simulation->addElement(fc_high_mid);
+
+		nf_low->addInput(mhk_low);
+		mhk_low->addInput(nf_low);
+		nf_low->addInput(nn_low);
+		nf_low->addInput(gs_low);
+
+		nf_mid->addInput(gk_mid);
+		gk_mid->addInput(nf_mid);
+		nf_mid->addInput(nn_mid);
+
+		nf_high->addInput(gk_high);
+		gk_high->addInput(nf_high);
+		nf_high->addInput(nn_high);
+
+		// Bottom-up: low drives mid, mid drives high.
+		fc_low_mid->addInput(nf_low);
+		nf_mid->addInput(fc_low_mid);
+
+		fc_mid_high->addInput(nf_mid);
+		nf_high->addInput(fc_mid_high);
+
+		// Top-down: high feeds back into mid.
+		fc_high_mid->addInput(nf_high);
+		nf_mid->addInput(fc_high_mid);
+
+		visualization->plot(
+			PlotCommonParameters{
+			PlotType::LINE_PLOT,
+			PlotDimensions{ 0.0, 280, -20.0, 20, 1.0, 1.0},
+			PlotAnnotations{ "low level field dynamics", "Spatial location", "Amplitude" } },
+			LinePlotParameters{},
+			{ { nf_low->getUniqueName(), "activation" }, { nf_low->getUniqueName(), "output" }, { nf_low->getUniqueName(), "input" } });
+
+		visualization->plot(
+			PlotCommonParameters{
+			PlotType::LINE_PLOT,
+			PlotDimensions{ 0.0, 150, -20.0, 20, 1.0, 1.0 },
+			PlotAnnotations{ "mid level field dynamics", "Spatial location", "Activation" } },
+			LinePlotParameters{},
+			{ {nf_mid->getUniqueName(), "activation"}, {nf_mid->getUniqueName(), "output"}, {nf_mid->getUniqueName(), "input"} });
+
+		visualization->plot(
+			PlotCommonParameters{
+			PlotType::LINE_PLOT,
+			PlotDimensions{ 0.0, 80, -20.0, 20, 1.0, 1.0 },
+			PlotAnnotations{ "high level field dynamics", "Spatial location", "Activation" } },
+			LinePlotParameters{},
+			{ {nf_high->getUniqueName(), "activation"}, {nf_high->getUniqueName(), "output"}, {nf_high->getUniqueName(), "input"} });
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::HEATMAP,
+				PlotDimensions{0.0, 150, 0.0, 280, 1.0, 1.0},
+				PlotAnnotations{"low-to-mid coupling", "mid spatial location", "low spatial location"} },
+				HeatmapParameters{},
+			{ {fc_low_mid->getUniqueName(), "weights"} }
+			);
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::HEATMAP,
+				PlotDimensions{0.0, 80, 0.0, 150, 1.0, 1.0},
+				PlotAnnotations{"mid-to-high coupling", "high spatial location", "mid spatial location"} },
+				HeatmapParameters{},
+			{ {fc_mid_high->getUniqueName(), "weights"} }
+			);
+
+		visualization->plot(
+			PlotCommonParameters{
+				PlotType::HEATMAP,
+				PlotDimensions{0.0, 150, 0.0, 80, 1.0, 1.0},
+				PlotAnnotations{"high-to-mid feedback coupling", "mid spatial location", "high spatial location"} },
+				HeatmapParameters{},
+			{ {fc_high_mid->getUniqueName(), "weights"} }
+			);
+
+		app.init();
+
+		while (!app.hasGUIBeenClosed())
+		{
+			app.step();
+		}
+
+		app.close();
+
+		return 0;
+	}
+	catch (const dnf_composer::Exception& ex)
+	{
+		const std::string errorMessage = "Exception: " + std::string(ex.what()) + " ErrorCode: " + std::to_string(static_cast<int>(ex.getErrorCode())) + ". ";
+		log(dnf_composer::tools::logger::LogLevel::FATAL, errorMessage, dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return static_cast<int>(ex.getErrorCode());
+	}
+	catch (const std::exception& ex)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Exception caught: " + std::string(ex.what()) + ". ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+	catch (...)
+	{
+		log(dnf_composer::tools::logger::LogLevel::FATAL, "Unknown exception occurred. ", dnf_composer::tools::logger::LogOutputMode::CONSOLE);
+		return 1;
+	}
+}


### PR DESCRIPTION
Closes #46.

Adds two self-contained multi-field architecture examples following the existing coupling-example idiom:
- `examples/bidirectional_architecture.cpp` — two same-size neural fields mutually coupled via two `FieldCoupling` elements (A→B and B→A), a closed reciprocal loop, with per-field line plots and per-coupling weight heatmaps.
- `examples/hierarchical_architecture.cpp` — three neural fields at decreasing resolution chained feedforward (low→mid→high) plus a top-down feedback coupling (high→mid); only the low field receives an external stimulus.

Both registered in `examples/CMakeLists.txt` (appended at EOF). Verified: both targets compile and link clean (Release, Ninja, MSVC).