### PR TITLE
fix: throw instead of dereferencing a failed dynamic_cast in ElementFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Every `ElementFactory` creator lambda (~30 of them) did
+  `dynamic_cast<const XParameters*>(&elementSpecificParameters)` and immediately
+  dereferenced the result without a null check; passing the wrong
+  `ElementSpecificParameters` subtype for a given `ElementLabel` was undefined
+  behavior in the public element-creation API. `createElement` also returned
+  `nullptr` for an unregistered/unknown `ElementLabel` instead of throwing,
+  pushing a null check onto every caller. Both `createElement` overloads now
+  throw a descriptive `Exception` on a parameter-type mismatch or an unknown
+  `ElementLabel`, in place of the dynamic_cast dereference and the nullptr
+  returns (#113)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/elements/element_factory.h
+++ b/dynamic-neural-field-composer/include/elements/element_factory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "exceptions/exception.h"
 #include "elements/element.h"
 #include "elements/gauss_kernel.h"
 #include "elements/gauss_stimulus.h"
@@ -53,8 +54,13 @@ namespace dnf_composer::element
 		/// @brief Create and return an element of the given type.
 		/// @param type                       Which element to create.
 		/// @param elementCommonParameters    Name, label, and spatial dimensions.
-		/// @param elementSpecificParameters  Type-specific parameter struct (cast internally).
+		/// @param elementSpecificParameters  Type-specific parameter struct (downcast internally
+		///                                   to the concrete type @p type expects).
 		/// @return Shared pointer to the new element.
+		/// @throws Exception if @p type has no registered creator (e.g. ElementLabel::UNINITIALIZED
+		///         or a value outside the defined enumerators), or if @p elementSpecificParameters
+		///         is not actually the concrete ElementSpecificParameters subtype that @p type
+		///         requires (#113 - previously undefined behavior via an unchecked dynamic_cast).
 		std::shared_ptr<Element> createElement(ElementLabel type,
 		                                       const ElementCommonParameters& elementCommonParameters,
 		                                       const ElementSpecificParameters& elementSpecificParameters);
@@ -62,6 +68,8 @@ namespace dnf_composer::element
 		/// @brief Create an element with default parameters.
 		/// @param type  Which element to create.
 		/// @return Shared pointer to the new element.
+		/// @throws Exception if @p type has no registered creator (e.g. ElementLabel::UNINITIALIZED
+		///         or a value outside the defined enumerators) (#113 - previously returned nullptr).
 		std::shared_ptr<Element> createElement(ElementLabel type);
 	private:
 		void setupElementCreators();

--- a/dynamic-neural-field-composer/src/elements/element_factory.cpp
+++ b/dynamic-neural-field-composer/src/elements/element_factory.cpp
@@ -1,8 +1,52 @@
 ﻿#include "elements/element_factory.h"
 
+#include "exceptions/exception.h"
 
 	namespace dnf_composer::element
 	{
+		namespace
+		{
+			/// @brief Human-readable name for an ElementLabel.
+			///
+			/// Falls back to the numeric value for labels outside the known enumeration
+			/// (ElementLabel is a plain enum, so a caller can construct an out-of-range
+			/// value via static_cast).
+			std::string labelName(const ElementLabel label)
+			{
+				const auto it = ElementLabelToString.find(label);
+				return it != ElementLabelToString.end()
+					? it->second
+					: "unknown (" + std::to_string(static_cast<int>(label)) + ")";
+			}
+
+			/// @brief Downcasts elementSpecificParameters to the concrete type a creator expects.
+			///
+			/// Every registered creator lambda receives its parameters through the common
+			/// ElementSpecificParameters base reference and must downcast to the concrete
+			/// type its element constructor needs. If the caller passed a mismatched
+			/// ElementSpecificParameters subtype, dynamic_cast returns nullptr; dereferencing
+			/// that pointer would be undefined behavior (#113), so this throws a descriptive
+			/// Exception instead.
+			///
+			/// @tparam ParamsT              Concrete ElementSpecificParameters subtype expected.
+			/// @param elementSpecificParameters  The parameters object supplied by the caller.
+			/// @param label                      The element type being constructed (for the message).
+			/// @param expectedTypeName           Name of ParamsT, for the error message.
+			/// @throws Exception if elementSpecificParameters is not actually a ParamsT.
+			template <typename ParamsT>
+			const ParamsT& requireParams(const ElementSpecificParameters& elementSpecificParameters,
+				const ElementLabel label, const char* expectedTypeName)
+			{
+				const auto* const params = dynamic_cast<const ParamsT*>(&elementSpecificParameters);
+				if (!params)
+				{
+					throw Exception("ElementFactory: cannot create a '" + labelName(label) +
+						"' element - expected parameters of type '" + expectedTypeName +
+						"', but received an incompatible ElementSpecificParameters subtype.");
+				}
+				return *params;
+			}
+		}
 
 		ElementFactory::ElementFactory()
 		{
@@ -11,173 +55,175 @@
 
 		void ElementFactory::setupElementCreators()
 		{
-			// Register element creators for each element type
+			// Register element creators for each element type. Each lambda downcasts
+			// elementSpecificParameters via requireParams<>(), which throws a descriptive
+			// Exception instead of dereferencing a failed dynamic_cast (#113).
 			elementCreators[ElementLabel::NEURAL_FIELD] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const NeuralFieldParameters*>(&elementSpecificParameters);
-					return std::make_shared<NeuralField>(elementCommonParameters, *params);
+					const auto& params = requireParams<NeuralFieldParameters>(elementSpecificParameters, ElementLabel::NEURAL_FIELD, "NeuralFieldParameters");
+					return std::make_shared<NeuralField>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::GAUSS_STIMULUS] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const GaussStimulusParameters*>(&elementSpecificParameters);
-					return std::make_shared<GaussStimulus>(elementCommonParameters, *params);
+					const auto& params = requireParams<GaussStimulusParameters>(elementSpecificParameters, ElementLabel::GAUSS_STIMULUS, "GaussStimulusParameters");
+					return std::make_shared<GaussStimulus>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::GAUSS_KERNEL] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const GaussKernelParameters*>(&elementSpecificParameters);
-					return std::make_shared<GaussKernel>(elementCommonParameters, *params);
+					const auto& params = requireParams<GaussKernelParameters>(elementSpecificParameters, ElementLabel::GAUSS_KERNEL, "GaussKernelParameters");
+					return std::make_shared<GaussKernel>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::MEXICAN_HAT_KERNEL] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const MexicanHatKernelParameters*>(&elementSpecificParameters);
-					return std::make_shared<MexicanHatKernel>(elementCommonParameters, *params);
+					const auto& params = requireParams<MexicanHatKernelParameters>(elementSpecificParameters, ElementLabel::MEXICAN_HAT_KERNEL, "MexicanHatKernelParameters");
+					return std::make_shared<MexicanHatKernel>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::NORMAL_NOISE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const NormalNoiseParameters*>(&elementSpecificParameters);
-					return std::make_shared<NormalNoise>(elementCommonParameters, *params);
+					const auto& params = requireParams<NormalNoiseParameters>(elementSpecificParameters, ElementLabel::NORMAL_NOISE, "NormalNoiseParameters");
+					return std::make_shared<NormalNoise>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::CORRELATED_NORMAL_NOISE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const CorrelatedNormalNoiseParameters*>(&elementSpecificParameters);
-					return std::make_shared<CorrelatedNormalNoise>(elementCommonParameters, *params);
+					const auto& params = requireParams<CorrelatedNormalNoiseParameters>(elementSpecificParameters, ElementLabel::CORRELATED_NORMAL_NOISE, "CorrelatedNormalNoiseParameters");
+					return std::make_shared<CorrelatedNormalNoise>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::GAUSS_FIELD_COUPLING] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const GaussFieldCouplingParameters*>(&elementSpecificParameters);
-					return std::make_shared<GaussFieldCoupling>(elementCommonParameters, *params);
+					const auto& params = requireParams<GaussFieldCouplingParameters>(elementSpecificParameters, ElementLabel::GAUSS_FIELD_COUPLING, "GaussFieldCouplingParameters");
+					return std::make_shared<GaussFieldCoupling>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::FIELD_COUPLING] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const FieldCouplingParameters*>(&elementSpecificParameters);
-					return std::make_shared<FieldCoupling>(elementCommonParameters, *params);
+					const auto& params = requireParams<FieldCouplingParameters>(elementSpecificParameters, ElementLabel::FIELD_COUPLING, "FieldCouplingParameters");
+					return std::make_shared<FieldCoupling>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::OSCILLATORY_KERNEL] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const OscillatoryKernelParameters*>(&elementSpecificParameters);
-					return std::make_shared<OscillatoryKernel>(elementCommonParameters, *params);
+					const auto& params = requireParams<OscillatoryKernelParameters>(elementSpecificParameters, ElementLabel::OSCILLATORY_KERNEL, "OscillatoryKernelParameters");
+					return std::make_shared<OscillatoryKernel>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::ASYMMETRIC_GAUSS_KERNEL] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const AsymmetricGaussKernelParameters*>(&elementSpecificParameters);
-					return std::make_shared<AsymmetricGaussKernel>(elementCommonParameters, *params);
+					const auto& params = requireParams<AsymmetricGaussKernelParameters>(elementSpecificParameters, ElementLabel::ASYMMETRIC_GAUSS_KERNEL, "AsymmetricGaussKernelParameters");
+					return std::make_shared<AsymmetricGaussKernel>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::BOOST_STIMULUS] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const BoostStimulusParameters*>(&elementSpecificParameters);
-					return std::make_shared<BoostStimulus>(elementCommonParameters, *params);
+					const auto& params = requireParams<BoostStimulusParameters>(elementSpecificParameters, ElementLabel::BOOST_STIMULUS, "BoostStimulusParameters");
+					return std::make_shared<BoostStimulus>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::MEMORY_TRACE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const MemoryTraceParameters*>(&elementSpecificParameters);
-					return std::make_shared<MemoryTrace>(elementCommonParameters, *params);
+					const auto& params = requireParams<MemoryTraceParameters>(elementSpecificParameters, ElementLabel::MEMORY_TRACE, "MemoryTraceParameters");
+					return std::make_shared<MemoryTrace>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::NEURAL_FIELD_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const NeuralField2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<NeuralField2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<NeuralField2DParameters>(elementSpecificParameters, ElementLabel::NEURAL_FIELD_2D, "NeuralField2DParameters");
+					return std::make_shared<NeuralField2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::GAUSS_STIMULUS_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const GaussStimulus2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<GaussStimulus2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<GaussStimulus2DParameters>(elementSpecificParameters, ElementLabel::GAUSS_STIMULUS_2D, "GaussStimulus2DParameters");
+					return std::make_shared<GaussStimulus2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::GAUSS_KERNEL_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const GaussKernel2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<GaussKernel2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<GaussKernel2DParameters>(elementSpecificParameters, ElementLabel::GAUSS_KERNEL_2D, "GaussKernel2DParameters");
+					return std::make_shared<GaussKernel2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::MEXICAN_HAT_KERNEL_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const MexicanHatKernel2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<MexicanHatKernel2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<MexicanHatKernel2DParameters>(elementSpecificParameters, ElementLabel::MEXICAN_HAT_KERNEL_2D, "MexicanHatKernel2DParameters");
+					return std::make_shared<MexicanHatKernel2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::NORMAL_NOISE_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const NormalNoise2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<NormalNoise2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<NormalNoise2DParameters>(elementSpecificParameters, ElementLabel::NORMAL_NOISE_2D, "NormalNoise2DParameters");
+					return std::make_shared<NormalNoise2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::OSCILLATORY_KERNEL_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const OscillatoryKernel2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<OscillatoryKernel2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<OscillatoryKernel2DParameters>(elementSpecificParameters, ElementLabel::OSCILLATORY_KERNEL_2D, "OscillatoryKernel2DParameters");
+					return std::make_shared<OscillatoryKernel2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::TIMED_GAUSS_STIMULUS] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const TimedGaussStimulusParameters*>(&elementSpecificParameters);
-					return std::make_shared<TimedGaussStimulus>(elementCommonParameters, *params);
+					const auto& params = requireParams<TimedGaussStimulusParameters>(elementSpecificParameters, ElementLabel::TIMED_GAUSS_STIMULUS, "TimedGaussStimulusParameters");
+					return std::make_shared<TimedGaussStimulus>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::TIMED_GAUSS_STIMULUS_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const TimedGaussStimulus2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<TimedGaussStimulus2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<TimedGaussStimulus2DParameters>(elementSpecificParameters, ElementLabel::TIMED_GAUSS_STIMULUS_2D, "TimedGaussStimulus2DParameters");
+					return std::make_shared<TimedGaussStimulus2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::BOOST_STIMULUS_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const BoostStimulus2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<BoostStimulus2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<BoostStimulus2DParameters>(elementSpecificParameters, ElementLabel::BOOST_STIMULUS_2D, "BoostStimulus2DParameters");
+					return std::make_shared<BoostStimulus2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::CORRELATED_NORMAL_NOISE_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const CorrelatedNormalNoise2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<CorrelatedNormalNoise2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<CorrelatedNormalNoise2DParameters>(elementSpecificParameters, ElementLabel::CORRELATED_NORMAL_NOISE_2D, "CorrelatedNormalNoise2DParameters");
+					return std::make_shared<CorrelatedNormalNoise2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::ASYMMETRIC_GAUSS_KERNEL_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const AsymmetricGaussKernel2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<AsymmetricGaussKernel2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<AsymmetricGaussKernel2DParameters>(elementSpecificParameters, ElementLabel::ASYMMETRIC_GAUSS_KERNEL_2D, "AsymmetricGaussKernel2DParameters");
+					return std::make_shared<AsymmetricGaussKernel2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::MEMORY_TRACE_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const MemoryTrace2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<MemoryTrace2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<MemoryTrace2DParameters>(elementSpecificParameters, ElementLabel::MEMORY_TRACE_2D, "MemoryTrace2DParameters");
+					return std::make_shared<MemoryTrace2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::RESIZE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const ResizeParameters*>(&elementSpecificParameters);
-					return std::make_shared<Resize>(elementCommonParameters, *params);
+					const auto& params = requireParams<ResizeParameters>(elementSpecificParameters, ElementLabel::RESIZE, "ResizeParameters");
+					return std::make_shared<Resize>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::RESIZE_2D] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const Resize2DParameters*>(&elementSpecificParameters);
-					return std::make_shared<Resize2D>(elementCommonParameters, *params);
+					const auto& params = requireParams<Resize2DParameters>(elementSpecificParameters, ElementLabel::RESIZE_2D, "Resize2DParameters");
+					return std::make_shared<Resize2D>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::COLLAPSE] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const CollapseParameters*>(&elementSpecificParameters);
-					return std::make_shared<Collapse>(elementCommonParameters, *params);
+					const auto& params = requireParams<CollapseParameters>(elementSpecificParameters, ElementLabel::COLLAPSE, "CollapseParameters");
+					return std::make_shared<Collapse>(elementCommonParameters, params);
 				};
 
 			elementCreators[ElementLabel::EXPAND] = [](const ElementCommonParameters& elementCommonParameters, const ElementSpecificParameters& elementSpecificParameters)
 				{
-					const auto *const params = dynamic_cast<const ExpandParameters*>(&elementSpecificParameters);
-					return std::make_shared<Expand>(elementCommonParameters, *params);
+					const auto& params = requireParams<ExpandParameters>(elementSpecificParameters, ElementLabel::EXPAND, "ExpandParameters");
+					return std::make_shared<Expand>(elementCommonParameters, params);
 				};
 
 			}
@@ -190,8 +236,8 @@
 			{
 				return creator->second(elementCommonParameters, elementSpecificParameters);
 			}
-			
-				return nullptr;
+
+			throw Exception("ElementFactory: no element creator registered for ElementLabel '" + labelName(type) + "'.");
 		}
 		std::shared_ptr<Element> ElementFactory::createElement(ElementLabel type)
 		{
@@ -258,9 +304,13 @@
 					case ElementLabel::EXPAND:
 						return creator->second(ElementCommonParameters(type), ExpandParameters());
 					case ElementLabel::UNINITIALIZED:
-						return nullptr;
+						// Unreachable: UNINITIALIZED has no registered creator, so the
+						// enclosing `creator != elementCreators.end()` check above already
+						// excludes it; kept only so the switch stays exhaustive over
+						// ElementLabel. Falls through to the throw below regardless.
+						break;
 				}
 			}
-			return nullptr;
+			throw Exception("ElementFactory: no element creator registered for ElementLabel '" + labelName(type) + "'.");
 		}
 	}

--- a/dynamic-neural-field-composer/tests/elements/test_element_factory.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_element_factory.cpp
@@ -12,6 +12,10 @@
 #include "elements/oscillatory_kernel.h"
 #include "elements/asymmetric_gauss_kernel.h"
 #include "elements/activation_function.h"
+#include "elements/resize.h"
+#include "elements/collapse.h"
+#include "elements/expand.h"
+#include "exceptions/exception.h"
 
 using namespace dnf_composer;
 using namespace dnf_composer::element;
@@ -113,13 +117,15 @@ TEST(ElementFactoryTest, CreateAsymmetricGaussKernelWithParams)
     EXPECT_EQ(el->getLabel(), ElementLabel::ASYMMETRIC_GAUSS_KERNEL);
 }
 
-TEST(ElementFactoryTest, CreateUninitializedWithParamsReturnsNullptr)
+TEST(ElementFactoryTest, CreateUninitializedWithParamsThrows)
 {
+    // ElementLabel::UNINITIALIZED has no registered creator. The factory must throw
+    // a descriptive Exception rather than silently returning nullptr (#113), so this
+    // failure can't be missed by a caller that forgets to null-check.
     ElementFactory factory;
     ElementCommonParameters cp{ "x", 100 };
     NeuralFieldParameters nfp{};
-    const auto el = factory.createElement(ElementLabel::UNINITIALIZED, cp, nfp);
-    EXPECT_EQ(el, nullptr);
+    EXPECT_THROW(factory.createElement(ElementLabel::UNINITIALIZED, cp, nfp), dnf_composer::Exception);
 }
 
 // ---------------------------------------------------------------------------
@@ -198,11 +204,24 @@ TEST(ElementFactoryTest, CreateAsymmetricGaussKernelDefault)
     EXPECT_EQ(el->getLabel(), ElementLabel::ASYMMETRIC_GAUSS_KERNEL);
 }
 
-TEST(ElementFactoryTest, CreateUninitializedDefaultReturnsNullptr)
+TEST(ElementFactoryTest, CreateUninitializedDefaultThrows)
 {
+    // Same as above but through the default-parameter overload.
     ElementFactory factory;
-    const auto el = factory.createElement(ElementLabel::UNINITIALIZED);
-    EXPECT_EQ(el, nullptr);
+    EXPECT_THROW(factory.createElement(ElementLabel::UNINITIALIZED), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, CreateWithOutOfRangeLabelThrows)
+{
+    // ElementLabel is a plain (non-class) enum backed by int, so a caller can construct
+    // a value entirely outside the defined enumerators (e.g. via static_cast). This must
+    // also throw rather than fall through to nullptr or UB.
+    ElementFactory factory;
+    ElementCommonParameters cp{ "x", 100 };
+    NeuralFieldParameters nfp{};
+    const auto bogus = static_cast<ElementLabel>(9999);
+    EXPECT_THROW(factory.createElement(bogus, cp, nfp), dnf_composer::Exception);
+    EXPECT_THROW(factory.createElement(bogus), dnf_composer::Exception);
 }
 
 // ---------------------------------------------------------------------------
@@ -218,4 +237,107 @@ TEST(ElementFactoryTest, TwoCreatedElementsHaveDistinctIdentifiers)
     ASSERT_NE(el2, nullptr);
     EXPECT_NE(el1.get(), el2.get());
     EXPECT_NE(el1->getUniqueIdentifier(), el2->getUniqueIdentifier());
+}
+
+// ---------------------------------------------------------------------------
+// Wrong ElementSpecificParameters subtype (#113) — must throw, never dereference
+// a failed dynamic_cast.
+// ---------------------------------------------------------------------------
+
+TEST(ElementFactoryTest, CreateNeuralFieldWithWrongParameterTypeThrows)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "nf", 100 };
+    const GaussStimulusParameters wrongParams{ 5.0, 15.0, 50.0, true, false };
+    EXPECT_THROW(factory.createElement(ElementLabel::NEURAL_FIELD, cp, wrongParams), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, CreateGaussStimulusWithWrongParameterTypeThrows)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "gs", 100 };
+    const NeuralFieldParameters wrongParams{};
+    EXPECT_THROW(factory.createElement(ElementLabel::GAUSS_STIMULUS, cp, wrongParams), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, CreateResizeWithWrongParameterTypeThrows)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "rs", 100 };
+    const ExpandParameters wrongParams{};
+    EXPECT_THROW(factory.createElement(ElementLabel::RESIZE, cp, wrongParams), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, CreateCollapseWithWrongParameterTypeThrows)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "cl", 100 };
+    const ExpandParameters wrongParams{};
+    EXPECT_THROW(factory.createElement(ElementLabel::COLLAPSE, cp, wrongParams), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, CreateExpandWithWrongParameterTypeThrows)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "ex", 100 };
+    const CollapseParameters wrongParams{};
+    EXPECT_THROW(factory.createElement(ElementLabel::EXPAND, cp, wrongParams), dnf_composer::Exception);
+}
+
+TEST(ElementFactoryTest, WrongParameterTypeThrowExceptionHasDescriptiveMessage)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "nf", 100 };
+    const GaussStimulusParameters wrongParams{ 5.0, 15.0, 50.0, true, false };
+    try
+    {
+        factory.createElement(ElementLabel::NEURAL_FIELD, cp, wrongParams);
+        FAIL() << "Expected Exception to be thrown";
+    }
+    catch (const dnf_composer::Exception& e)
+    {
+        const std::string msg = e.what();
+        EXPECT_NE(msg.find("NeuralField"), std::string::npos) << "message was: " << msg;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wrong parameter subtype, swept over every registered ElementLabel.
+// ---------------------------------------------------------------------------
+
+class ElementFactoryWrongParameterTypeSweep : public ::testing::TestWithParam<ElementLabel> {};
+
+INSTANTIATE_TEST_SUITE_P(AllRegisteredLabels, ElementFactoryWrongParameterTypeSweep, ::testing::Values(
+    ElementLabel::NEURAL_FIELD, ElementLabel::GAUSS_STIMULUS, ElementLabel::BOOST_STIMULUS,
+    ElementLabel::GAUSS_KERNEL, ElementLabel::MEXICAN_HAT_KERNEL, ElementLabel::OSCILLATORY_KERNEL,
+    ElementLabel::ASYMMETRIC_GAUSS_KERNEL, ElementLabel::NORMAL_NOISE, ElementLabel::CORRELATED_NORMAL_NOISE,
+    ElementLabel::FIELD_COUPLING, ElementLabel::GAUSS_FIELD_COUPLING, ElementLabel::MEMORY_TRACE,
+    ElementLabel::NEURAL_FIELD_2D, ElementLabel::GAUSS_STIMULUS_2D, ElementLabel::GAUSS_KERNEL_2D,
+    ElementLabel::MEXICAN_HAT_KERNEL_2D, ElementLabel::NORMAL_NOISE_2D, ElementLabel::OSCILLATORY_KERNEL_2D,
+    ElementLabel::TIMED_GAUSS_STIMULUS, ElementLabel::TIMED_GAUSS_STIMULUS_2D, ElementLabel::BOOST_STIMULUS_2D,
+    ElementLabel::CORRELATED_NORMAL_NOISE_2D, ElementLabel::ASYMMETRIC_GAUSS_KERNEL_2D, ElementLabel::MEMORY_TRACE_2D,
+    ElementLabel::RESIZE, ElementLabel::RESIZE_2D, ElementLabel::COLLAPSE, ElementLabel::EXPAND
+));
+
+TEST_P(ElementFactoryWrongParameterTypeSweep, ThrowsInsteadOfDereferencingFailedCast)
+{
+    ElementFactory factory;
+    ElementCommonParameters cp{ "x", 100 };
+    const ElementLabel label = GetParam();
+
+    // Every registered creator expects its own concrete ElementSpecificParameters
+    // subtype. ExpandParameters is a mismatch for every label except EXPAND itself,
+    // for which CollapseParameters is used instead - both are unrelated sibling
+    // types (each derives directly and solely from ElementSpecificParameters), so
+    // dynamic_cast to the expected type always fails here.
+    if (label == ElementLabel::EXPAND)
+    {
+        const CollapseParameters wrongParams{};
+        EXPECT_THROW(factory.createElement(label, cp, wrongParams), dnf_composer::Exception);
+    }
+    else
+    {
+        const ExpandParameters wrongParams{};
+        EXPECT_THROW(factory.createElement(label, cp, wrongParams), dnf_composer::Exception);
+    }
 }

--- a/dynamic-neural-field-composer/wiki/How to Add New Elements.md
+++ b/dynamic-neural-field-composer/wiki/How to Add New Elements.md
@@ -159,10 +159,16 @@ Add the include near the end of the existing list:
 elementCreators[ElementLabel::YOUR_ELEMENT_NAME] =
     [](const ElementCommonParameters& cp, const ElementSpecificParameters& sp)
     {
-        const auto params = dynamic_cast<const YourElementParameters*>(&sp);
-        return std::make_shared<YourElement>(cp, *params);
+        const auto& params = requireParams<YourElementParameters>(sp, ElementLabel::YOUR_ELEMENT_NAME, "YourElementParameters");
+        return std::make_shared<YourElement>(cp, params);
     };
 ```
+
+> Do **not** `dynamic_cast` and dereference the result directly — if a caller passes the
+> wrong `ElementSpecificParameters` subtype, the cast returns `nullptr` and dereferencing
+> it is undefined behavior (this was issue #113). `requireParams<>()` is a small helper
+> local to `element_factory.cpp` that does the same `dynamic_cast` but throws a
+> descriptive `Exception` instead of returning nullptr/UB when the cast fails.
 
 **4b.** In `ElementFactory::createElement(ElementLabel type)` switch, add before `case ElementLabel::UNINITIALIZED`:
 


### PR DESCRIPTION
The ~28 creator lambdas in `ElementFactory` did:

```cpp
const auto params = dynamic_cast<const NeuralFieldParameters*>(&elementSpecificParameters);
return std::make_shared<NeuralField>(elementCommonParameters, *params);   // UB if params == nullptr
```

Passing the wrong `ElementSpecificParameters` subtype yields `nullptr`, which is then dereferenced — undefined behaviour in the public creation API. `createElement` also returned `nullptr` for an unknown `ElementLabel`, pushing null checks onto every caller.

### Changes

- Added a `requireParams<ParamsT>()` helper that performs the `dynamic_cast` and throws a descriptive `Exception` naming the element and the expected parameter type. It returns a reference, so there is no raw pointer left to dereference. All creators go through it.
- Both `createElement` overloads now throw on an unknown/unregistered `ElementLabel` instead of returning `nullptr` (including out-of-range values, since `ElementLabel` is a plain `enum : int`).
- Doxygen `@throws` on both public overloads; `wiki/How to Add New Elements.md` step 4a updated so new elements follow the safe pattern rather than reintroducing the bug.

Same approach as #96, which made invalid `ElementDimensions` fail loudly rather than silently.

### Tests

Written first, and confirmed failing before the fix — the wrong-subtype cases crashed with `SEH exception with code 0xc0000005` (the UB), and the unknown-label cases reported `it throws nothing`. Now: the two existing "returns nullptr" tests became `EXPECT_THROW`, plus an out-of-range-label test, 5 representative wrong-subtype tests, a message-content check, and a `TEST_P` sweep over all 28 registered labels with a mismatched parameter type.

`*ElementFactory*`: 56/56. Full suite: 1131/1133 — the 2 failures are `LoggerTest.LogProducesOutput` / `LogOutputContainsMessage`, which are pre-existing and order-dependent on `main` (they pass in isolation) and are fixed separately in #140; they are unrelated to this change.

Backwards compatible for valid input: behaviour is unchanged whenever the parameter type matches.

Closes #113
