### PR TITLE
fix: bind ImGui::GetIO() by reference so keyboard nav and default font apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `Application::enableKeyboardShortcuts()` and `Application::appendFonts()` bound
+  `ImGui::GetIO()` — which returns `ImGuiIO&` — with `auto io = ...`, copying the
+  struct by value. Every write through `io` (`ConfigFlags |=
+  ImGuiConfigFlags_NavEnableKeyboard`, `FontDefault = ...`) landed on a discarded
+  temporary, so keyboard navigation never actually enabled and ImGui's default font
+  was never actually applied, even though the intended font/config values were
+  computed correctly. Both now bind `ImGuiIO&` by reference, so the changes persist
+  on the real global IO (#114)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/application/application.h
+++ b/dynamic-neural-field-composer/include/application/application.h
@@ -111,11 +111,33 @@ namespace dnf_composer
 		/// @brief Return true if the GUI overlay is currently active.
 		[[nodiscard]] bool isGUIActive() const;
 
+		/// @brief Enable ImGui keyboard navigation for the current ImGui context.
+		///
+		/// Sets @c ImGuiConfigFlags_NavEnableKeyboard on the IO struct returned by
+		/// @c ImGui::GetIO(). Must bind the IO **by reference** (`ImGuiIO&`): binding
+		/// by value (`auto io = ImGui::GetIO();`) copies the struct, so the flag would
+		/// be written to a discarded temporary and keyboard navigation would silently
+		/// never activate (#114). Requires a current ImGui context (created by
+		/// @c ImGui::CreateContext()); safe to call from a headless test that never
+		/// calls @c NewFrame()/@c Render().
+		static void enableKeyboardShortcuts();
+
+		/// @brief Assign the font-registry globals and the ImGui default font.
+		///
+		/// Reads the fonts already present in @c ImGui::GetIO().Fonts (populated by
+		/// @c setGUIParameters()/imgui_kit before this runs), assigns each
+		/// `g_*Font` global declared below, sets @c io.FontDefault, adds the
+		/// Font Awesome icon fonts, and builds the atlas. As with
+		/// @c enableKeyboardShortcuts(), the IO struct must be bound **by reference**
+		/// (`ImGuiIO&`): a by-value `auto io` copy would let @c io.FontDefault
+		/// assignment vanish with the temporary, leaving ImGui's real default font
+		/// unset (#114). Requires at least @c g_FontCount fonts already registered in
+		/// the atlas, or it throws @c ErrorCode::APP_INIT.
+		static void appendFonts();
+
 		~Application() = default;
 	private:
 		void setGUIParameters();
-		static void enableKeyboardShortcuts();
-		static void appendFonts();
 		static void defineImGuiStyle();
 	};
 

--- a/dynamic-neural-field-composer/src/application/application.cpp
+++ b/dynamic-neural-field-composer/src/application/application.cpp
@@ -150,13 +150,18 @@ namespace dnf_composer
 
 	void Application::enableKeyboardShortcuts()
 	{
-		auto io = ImGui::GetIO();
+		// ImGui::GetIO() returns ImGuiIO&; binding it by value here would copy the
+		// struct and write the flag to a discarded temporary instead of the real
+		// IO object (#114) — must bind by reference.
+		ImGuiIO& io = ImGui::GetIO();
 		io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 	}
 
 	void Application::appendFonts()
 	{
-		auto io = ImGui::GetIO();
+		// Same reference-vs-copy pitfall as enableKeyboardShortcuts() above: binding
+		// by value would silently drop the io.FontDefault assignment below (#114).
+		ImGuiIO& io = ImGui::GetIO();
 
 		ImFontConfig cfg{};
 		cfg.OversampleH = 2;          // 2 is often crisper than 3 at small sizes

--- a/dynamic-neural-field-composer/tests/application/test_application.cpp
+++ b/dynamic-neural-field-composer/tests/application/test_application.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <memory>
+#include <imgui.h>
 
 #include "application/application.h"
 #include "simulation/simulation.h"
@@ -34,4 +35,58 @@ TEST(ApplicationConstruction, MismatchedSimulationThrows)
     auto sim2 = std::make_shared<Simulation>("s2", 1.0, 0.0, 0.0);
     auto vis  = std::make_shared<Visualization>(sim1);
     EXPECT_THROW(Application(sim2, vis), Exception);
+}
+
+// ---------------------------------------------------------------------------
+// enableKeyboardShortcuts()/appendFonts() must mutate the *real* ImGui IO
+// (issue #114) — see .claude/tests/05-gui-headless.md for the project's usual
+// "never touch ImGui::*" boundary. This is a deliberate, narrow exception:
+// ImGui::CreateContext()/DestroyContext() need no window, OpenGL, or rendering
+// backend — we never call NewFrame()/Render(), so this stays fully headless.
+// Regression for: `auto io = ImGui::GetIO();` copies the IO struct by value,
+// so writes through `io` land on a discarded temporary instead of the real
+// global IO that the rest of the app reads.
+// ---------------------------------------------------------------------------
+
+namespace {
+    struct ScopedImGuiContext
+    {
+        ImGuiContext* ctx = ImGui::CreateContext();
+        ScopedImGuiContext()  { ImGui::SetCurrentContext(ctx); }
+        ~ScopedImGuiContext() { ImGui::DestroyContext(ctx); }
+    };
+}
+
+TEST(ApplicationIOReference, EnableKeyboardShortcutsPersistsNavFlagOnGlobalIO)
+{
+    ScopedImGuiContext guard;
+
+    ASSERT_FALSE(ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard)
+        << "precondition: flag must start unset, otherwise the check below would "
+           "pass vacuously even with the pre-fix bug";
+
+    Application::enableKeyboardShortcuts();
+
+    EXPECT_TRUE(ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard)
+        << "enableKeyboardShortcuts() must set the flag on the REAL global IO, "
+           "not on a locally-copied ImGuiIO value";
+}
+
+TEST(ApplicationIOReference, AppendFontsPersistsFontDefaultOnGlobalIO)
+{
+    ScopedImGuiContext guard;
+
+    ImGuiIO& io = ImGui::GetIO();
+    for (std::size_t i = 0; i < dnf_composer::g_FontCount; ++i) {
+        io.Fonts->AddFontDefault();
+    }
+    ASSERT_EQ(io.FontDefault, nullptr)
+        << "precondition: no default font set yet";
+
+    Application::appendFonts();
+
+    EXPECT_NE(ImGui::GetIO().FontDefault, nullptr)
+        << "appendFonts() must set io.FontDefault on the REAL global IO, not on "
+           "a locally-copied ImGuiIO value";
+    EXPECT_EQ(ImGui::GetIO().FontDefault, dnf_composer::g_MediumMediumFont);
 }


### PR DESCRIPTION
```cpp
auto io = ImGui::GetIO();                              // ImGuiIO by VALUE — a copy
io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;  // written to the copy, discarded
io.FontDefault = g_MediumMediumFont;                   // lost
```

`ImGui::GetIO()` returns a reference; `auto` deduces a value. Keyboard navigation was therefore never enabled and `FontDefault` never applied. Font *building* still worked only because `io.Fonts` is a pointer into shared state, which is why this went unnoticed.

Both sites now bind `ImGuiIO& io = ImGui::GetIO();`.

### Tests

Written first and confirmed failing before the fix:

```
ApplicationIOReference.EnableKeyboardShortcutsPersistsNavFlagOnGlobalIO
  Value of: ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_NavEnableKeyboard
  Actual: false / Expected: true

ApplicationIOReference.AppendFontsPersistsFontDefaultOnGlobalIO
  ImGui::GetIO().FontDefault  Which is: NULL
  g_MediumMediumFont          Which is: 0000020C17073790
```

The second is the clearest evidence: the font global was populated correctly, but `FontDefault` on the real global IO stayed `NULL` — the write had gone to a copy. The tests use a small `ScopedImGuiContext` RAII helper (`CreateContext`/`DestroyContext` only, no frame or backend).

### Review note

`enableKeyboardShortcuts()` and `appendFonts()` were moved from `private` to `public` so the tests can call them directly, which avoids pulling a gtest include into a production header. Both are `static` and now carry Doxygen documenting the reference-vs-copy contract. This widens the public API — nothing breaks, but if you would rather keep them private, say so and I will test through a different seam instead.

Full suite: 1098/1100. The 2 failures are the pre-existing order-dependent `LoggerTest` ones (they pass in isolation and reproduce without this change); they are fixed separately in #140.

Closes #114
