### PR TITLE
fix: compare NeuralFieldParameters activation functions by value and complete the rule of five

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable changes to this project will be documented in this file.
   function on the next `init()`/`step()`); both now agree on the constructor's
   default-substitution policy. Move constructor and move assignment were also missing
   entirely, so moves silently degraded into deep-cloning copies; both are now declared
-  and transfer ownership directly (#119)
+  and transfer ownership directly. Copy assignment now clones before assigning any
+  member, so a throwing `clone()` leaves the destination unchanged (#119)
 
 ## [2.9.6] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `NeuralFieldParameters::operator==` compared the `activationFunction` `unique_ptr` by
+  address instead of by value, so two independently-constructed parameter sets with
+  identical activation functions compared unequal. It now dispatches to the concrete
+  activation function's own value `operator==` (guarding against two different
+  activation-function types with numerically-coincidental fields wrongly comparing
+  equal). Separately, the copy constructor and copy assignment disagreed on null-source
+  handling (the constructor substituted a default `SigmoidFunction(0, 10)`; assignment
+  reset to `nullptr`, which could leave a `NeuralField` dereferencing a null activation
+  function on the next `init()`/`step()`); both now agree on the constructor's
+  default-substitution policy. Move constructor and move assignment were also missing
+  entirely, so moves silently degraded into deep-cloning copies; both are now declared
+  and transfer ownership directly (#119)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/elements/neural_field.h
+++ b/dynamic-neural-field-composer/include/elements/neural_field.h
@@ -8,35 +8,33 @@
 namespace dnf_composer::element
 {
 	/// @brief Parameters that govern a NeuralField's dynamics.
+	///
+	/// ### Copy / move semantics (rule of five)
+	/// `activationFunction` is a `unique_ptr<ActivationFunction>`, so this type owns a
+	/// polymorphic value and cannot rely on compiler-generated copy/move:
+	///  - **Copy** (constructor and assignment) deep-clones the source's activation
+	///    function via `ActivationFunction::clone()`. **Null policy:** if the source's
+	///    `activationFunction` is null, the copy materializes a default
+	///    `SigmoidFunction(0, 10)` rather than propagating null. This is required for
+	///    correctness, not just consistency: `NeuralField::calculateOutput()`
+	///    dereferences `parameters.activationFunction` unconditionally (no null check),
+	///    and `ElementFactory::createElement(NEURAL_FIELD)` constructs a default,
+	///    null-activation `NeuralFieldParameters` that reaches a `NeuralField` only
+	///    through this copy path -- so "null copies to null" would leave a
+	///    `NeuralField` with a dangling dereference on the very next `init()`/`step()`.
+	///    Copy constructor and copy assignment intentionally agree on this policy
+	///    (previously they did not: the constructor substituted a default sigmoid while
+	///    assignment reset to null -- see issue #119).
+	///  - **Move** (constructor and assignment) transfers ownership of the source's
+	///    `activationFunction` pointer directly -- no clone, no allocation. The
+	///    moved-from source is left with `activationFunction == nullptr`, the same
+	///    valid "unconfigured" state as a default-constructed instance.
 	/// @ingroup elements
 	struct NeuralFieldParameters final : ElementSpecificParameters
 	{
 		double tau;                                             ///< Time constant of the field's relaxation dynamics.
 		double startingRestingLevel;                            ///< Homogeneous resting level (h); sub-threshold when negative.
 		std::unique_ptr<ActivationFunction> activationFunction; ///< Nonlinearity applied to activation to produce output.
-
-		NeuralFieldParameters& operator=(const NeuralFieldParameters& other)
-		{
-			if (this != &other)
-			{
-				tau = other.tau;
-				startingRestingLevel = other.startingRestingLevel;
-				if (other.activationFunction) {
-					activationFunction = other.activationFunction->clone();
-				} else {
-					activationFunction.reset();
-}
-			}
-			return *this;
-		}
-
-		bool operator==(const NeuralFieldParameters& other) const
-		{
-			constexpr double epsilon = 1e-6;
-			return std::abs(tau - other.tau) < epsilon &&
-				std::abs(startingRestingLevel - other.startingRestingLevel) < epsilon &&
-				activationFunction == other.activationFunction;
-		}
 
 		/// @brief Default constructor: tau=25, restingLevel=-5, sigmoid(0, 10).
 		NeuralFieldParameters()
@@ -53,15 +51,59 @@ namespace dnf_composer::element
 			  activationFunction(activationFunction.clone())
 		{ }
 
+		/// @brief Copy constructor. Deep-clones @p other's activation function.
+		/// See the class-level doc comment for the null-source policy (materializes
+		/// a default `SigmoidFunction(0, 10)`, matching copy assignment).
 		NeuralFieldParameters(const NeuralFieldParameters& other)
+			: tau(other.tau), startingRestingLevel(other.startingRestingLevel),
+			  activationFunction(other.activationFunction
+				  ? other.activationFunction->clone()
+				  : std::make_unique<SigmoidFunction>(0.0, 10.0))
+		{}
+
+		/// @brief Copy assignment. Deep-clones @p other's activation function.
+		/// Same null-source policy as the copy constructor -- see the class-level
+		/// doc comment.
+		NeuralFieldParameters& operator=(const NeuralFieldParameters& other)
 		{
-			tau = other.tau;
-			startingRestingLevel = other.startingRestingLevel;
-			if (other.activationFunction == nullptr) {
-				activationFunction = std::make_unique<SigmoidFunction>(0.0, 10.0);
-			} else {
-				activationFunction = other.activationFunction->clone();
-}
+			if (this != &other)
+			{
+				tau = other.tau;
+				startingRestingLevel = other.startingRestingLevel;
+				activationFunction = other.activationFunction
+					? other.activationFunction->clone()
+					: std::make_unique<SigmoidFunction>(0.0, 10.0);
+			}
+			return *this;
+		}
+
+		/// @brief Move constructor. Transfers @p other's activation function
+		/// (no clone). @p other is left with `activationFunction == nullptr`.
+		NeuralFieldParameters(NeuralFieldParameters&& other) noexcept = default;
+
+		/// @brief Move assignment. Transfers @p other's activation function
+		/// (no clone). @p other is left with `activationFunction == nullptr`.
+		NeuralFieldParameters& operator=(NeuralFieldParameters&& other) noexcept = default;
+
+		~NeuralFieldParameters() override = default;
+
+		/// @brief Value equality.
+		///
+		/// Compares @c tau and @c startingRestingLevel within an epsilon tolerance, and
+		/// compares @c activationFunction *by value* (concrete type and parameters) --
+		/// never by pointer identity. Two null activation functions compare equal; a
+		/// null and a non-null one never do; two non-null functions of different
+		/// concrete types never compare equal even when their numeric fields coincide
+		/// (e.g. a `SigmoidFunction(0, 10)` and an `AbsSigmoidFunction(0, 10)`).
+		bool operator==(const NeuralFieldParameters& other) const
+		{
+			constexpr double epsilon = 1e-6;
+			if (std::abs(tau - other.tau) >= epsilon ||
+				std::abs(startingRestingLevel - other.startingRestingLevel) >= epsilon)
+			{
+				return false;
+			}
+			return activationFunctionsEqual(activationFunction, other.activationFunction);
 		}
 
 		[[nodiscard]] std::string toString() const override
@@ -75,6 +117,49 @@ namespace dnf_composer::element
 			return result.str();
 		}
 
+	private:
+		/// @brief Value-compare two possibly-null activation functions.
+		///
+		/// Both null compares equal; exactly one null never compares equal. When both
+		/// are non-null, the concrete type is checked (via `dynamic_cast`, mirroring the
+		/// dispatch pattern already used in `simulation_file_manager.cpp`) before
+		/// delegating to that type's own value `operator==` -- this guards against two
+		/// different activation-function types with numerically-coincidental fields
+		/// wrongly comparing equal.
+		[[nodiscard]] static bool activationFunctionsEqual(
+			const std::unique_ptr<ActivationFunction>& lhs,
+			const std::unique_ptr<ActivationFunction>& rhs)
+		{
+			if (!lhs || !rhs) {
+				return !lhs && !rhs;
+			}
+			if (lhs->type != rhs->type) {
+				return false;
+			}
+			switch (lhs->type)
+			{
+			case ActivationFunctionType::SIGMOID:
+			{
+				const auto* l = dynamic_cast<const SigmoidFunction*>(lhs.get());
+				const auto* r = dynamic_cast<const SigmoidFunction*>(rhs.get());
+				return l && r && (*l == *r);
+			}
+			case ActivationFunctionType::HEAVISIDE:
+			{
+				const auto* l = dynamic_cast<const HeavisideFunction*>(lhs.get());
+				const auto* r = dynamic_cast<const HeavisideFunction*>(rhs.get());
+				return l && r && (*l == *r);
+			}
+			case ActivationFunctionType::ABSSIGMOID:
+			{
+				const auto* l = dynamic_cast<const AbsSigmoidFunction*>(lhs.get());
+				const auto* r = dynamic_cast<const AbsSigmoidFunction*>(rhs.get());
+				return l && r && (*l == *r);
+			}
+			default:
+				return false;
+			}
+		}
 	};
 
 	/// @brief Describes a single activation bump (peak) in a neural field.

--- a/dynamic-neural-field-composer/include/elements/neural_field.h
+++ b/dynamic-neural-field-composer/include/elements/neural_field.h
@@ -64,15 +64,20 @@ namespace dnf_composer::element
 		/// @brief Copy assignment. Deep-clones @p other's activation function.
 		/// Same null-source policy as the copy constructor -- see the class-level
 		/// doc comment.
+		///
+		/// Offers the strong exception guarantee: the clone is completed before any
+		/// member is touched, so a throwing `clone()` leaves `*this` unchanged
+		/// rather than holding @p other's scalars beside its own old function.
 		NeuralFieldParameters& operator=(const NeuralFieldParameters& other)
 		{
 			if (this != &other)
 			{
-				tau = other.tau;
-				startingRestingLevel = other.startingRestingLevel;
-				activationFunction = other.activationFunction
+				auto clonedActivationFunction = other.activationFunction
 					? other.activationFunction->clone()
 					: std::make_unique<SigmoidFunction>(0.0, 10.0);
+				tau = other.tau;
+				startingRestingLevel = other.startingRestingLevel;
+				activationFunction = std::move(clonedActivationFunction);
 			}
 			return *this;
 		}

--- a/dynamic-neural-field-composer/include/elements/neural_field.h
+++ b/dynamic-neural-field-composer/include/elements/neural_field.h
@@ -142,19 +142,19 @@ namespace dnf_composer::element
 			{
 				const auto* l = dynamic_cast<const SigmoidFunction*>(lhs.get());
 				const auto* r = dynamic_cast<const SigmoidFunction*>(rhs.get());
-				return l && r && (*l == *r);
+				return l != nullptr && r != nullptr && (*l == *r);
 			}
 			case ActivationFunctionType::HEAVISIDE:
 			{
 				const auto* l = dynamic_cast<const HeavisideFunction*>(lhs.get());
 				const auto* r = dynamic_cast<const HeavisideFunction*>(rhs.get());
-				return l && r && (*l == *r);
+				return l != nullptr && r != nullptr && (*l == *r);
 			}
 			case ActivationFunctionType::ABSSIGMOID:
 			{
 				const auto* l = dynamic_cast<const AbsSigmoidFunction*>(lhs.get());
 				const auto* r = dynamic_cast<const AbsSigmoidFunction*>(rhs.get());
-				return l && r && (*l == *r);
+				return l != nullptr && r != nullptr && (*l == *r);
 			}
 			default:
 				return false;

--- a/dynamic-neural-field-composer/src/elements/neural_field.cpp
+++ b/dynamic-neural-field-composer/src/elements/neural_field.cpp
@@ -17,8 +17,8 @@
 		}
 		
 
-		NeuralField::NeuralField(const ElementCommonParameters& elementCommonParameters, 
-			const NeuralFieldParameters& parameters)
+		NeuralField::NeuralField(const ElementCommonParameters& elementCommonParameters,
+			const NeuralFieldParameters& parameters) // NOLINT(modernize-pass-by-value) - every element constructor takes its parameters by const reference; changing only this one would break that uniform public signature
 			: Element(elementCommonParameters), parameters(parameters)
 		{
 			commonParameters.identifiers.label = ElementLabel::NEURAL_FIELD;

--- a/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
@@ -561,3 +561,154 @@ TEST(NeuralFieldStability, HugeThresholdIsStableQuickly)
     f->step(1.0, 1.0);
     EXPECT_TRUE(f->isStable());
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #119: NeuralFieldParameters::operator== compared
+// the activationFunction unique_ptr by address instead of by value, and the
+// type had a rule-of-five violation (copy ctor and copy assignment disagreed
+// on null handling; no move operations were declared, so moves silently
+// degraded to (deep-cloning) copies).
+// ---------------------------------------------------------------------------
+
+TEST(NeuralFieldParametersEquality, IdenticallyParameterizedSigmoidsCompareEqual)
+{
+    // Two independently-constructed parameter sets with numerically identical
+    // sigmoid activation functions must compare equal -- value equality, not
+    // pointer identity.
+    const NeuralFieldParameters a{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    const NeuralFieldParameters b{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    EXPECT_TRUE(a == b);
+}
+
+TEST(NeuralFieldParametersEquality, DifferentSigmoidParametersCompareNotEqual)
+{
+    const NeuralFieldParameters a{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    const NeuralFieldParameters b{ 25.0, -5.0, SigmoidFunction{ 0.0, 20.0 } };
+    EXPECT_FALSE(a == b);
+}
+
+TEST(NeuralFieldParametersEquality, SameNumericFieldsDifferentActivationTypeCompareNotEqual)
+{
+    // AbsSigmoidFunction(x_shift, beta) and SigmoidFunction(x_shift, steepness) can
+    // hold numerically-coincidental fields (0.0 and 10.0 here). Comparing polymorphic
+    // activation functions purely by field value (without a type check) would wrongly
+    // report these as equal.
+    const NeuralFieldParameters sigmoid{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    const NeuralFieldParameters absSigmoid{ 25.0, -5.0, AbsSigmoidFunction{ 0.0, 10.0 } };
+    EXPECT_FALSE(sigmoid == absSigmoid);
+}
+
+TEST(NeuralFieldParametersEquality, BothNullActivationFunctionsCompareEqual)
+{
+    const NeuralFieldParameters a; // default ctor: activationFunction == nullptr
+    const NeuralFieldParameters b;
+    EXPECT_TRUE(a == b);
+}
+
+TEST(NeuralFieldParametersEquality, NullVsNonNullActivationFunctionCompareNotEqual)
+{
+    const NeuralFieldParameters withNull;
+    const NeuralFieldParameters withSigmoid{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    EXPECT_FALSE(withNull == withSigmoid);
+    EXPECT_FALSE(withSigmoid == withNull);
+}
+
+TEST(NeuralFieldParametersEquality, DifferentTauStillCompareNotEqualWithSameActivation)
+{
+    const NeuralFieldParameters a{ 25.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    const NeuralFieldParameters b{ 30.0, -5.0, SigmoidFunction{ 0.0, 10.0 } };
+    EXPECT_FALSE(a == b);
+}
+
+// ---------------------------------------------------------------------------
+// Copy constructor / copy assignment: must produce equal results and agree on
+// null-source handling.
+// ---------------------------------------------------------------------------
+
+TEST(NeuralFieldParametersCopy, CopyConstructorPreservesActivationFunctionValue)
+{
+    const NeuralFieldParameters source{ 25.0, -5.0, SigmoidFunction{ 1.0, 12.0 } };
+    const NeuralFieldParameters copy(source); // NOLINT(performance-unnecessary-copy-initialization)
+    EXPECT_TRUE(copy == source);
+    ASSERT_NE(copy.activationFunction, nullptr);
+    const auto* sig = dynamic_cast<const SigmoidFunction*>(copy.activationFunction.get());
+    ASSERT_NE(sig, nullptr);
+    EXPECT_DOUBLE_EQ(sig->getXShift(), 1.0);
+    EXPECT_DOUBLE_EQ(sig->getSteepness(), 12.0);
+}
+
+TEST(NeuralFieldParametersCopy, CopyAssignmentPreservesActivationFunctionValue)
+{
+    const NeuralFieldParameters source{ 25.0, -5.0, SigmoidFunction{ 1.0, 12.0 } };
+    NeuralFieldParameters dest{ 0.0, 0.0, HeavisideFunction{ 3.0 } };
+    dest = source;
+    EXPECT_TRUE(dest == source);
+    ASSERT_NE(dest.activationFunction, nullptr);
+    const auto* sig = dynamic_cast<const SigmoidFunction*>(dest.activationFunction.get());
+    ASSERT_NE(sig, nullptr);
+    EXPECT_DOUBLE_EQ(sig->getXShift(), 1.0);
+    EXPECT_DOUBLE_EQ(sig->getSteepness(), 12.0);
+}
+
+TEST(NeuralFieldParametersCopy, CopyConstructorAndCopyAssignmentAgreeOnNullSource)
+{
+    // Regression for the core rule-of-five bug: the copy constructor used to
+    // substitute a default SigmoidFunction(0, 10) for a null source, while copy
+    // assignment reset() the destination to null instead. Both paths must now
+    // produce the exact same, equal result from the same null source.
+    const NeuralFieldParameters nullSource; // activationFunction == nullptr
+
+    const NeuralFieldParameters viaCtor(nullSource);
+
+    NeuralFieldParameters viaAssign{ 1.0, 1.0, HeavisideFunction{ 9.0 } };
+    viaAssign = nullSource;
+
+    EXPECT_TRUE(viaCtor == viaAssign)
+        << "copy ctor: " << viaCtor.toString() << " vs copy assign: " << viaAssign.toString();
+    // Both must leave the copy able to compute output (never null), since
+    // NeuralField::calculateOutput() dereferences activationFunction unconditionally.
+    EXPECT_NE(viaCtor.activationFunction, nullptr);
+    EXPECT_NE(viaAssign.activationFunction, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Move constructor / move assignment: must be true transfers, not clones.
+// ---------------------------------------------------------------------------
+
+TEST(NeuralFieldParametersMove, MoveConstructorTransfersOwnershipWithoutCloning)
+{
+    NeuralFieldParameters source{ 25.0, -5.0, SigmoidFunction{ 2.0, 15.0 } };
+    const ActivationFunction* rawBeforeMove = source.activationFunction.get();
+
+    const NeuralFieldParameters moved(std::move(source));
+
+    // A real move transfers the same pointee -- a clone-based "fake move" would
+    // allocate a new object at a different address.
+    EXPECT_EQ(moved.activationFunction.get(), rawBeforeMove);
+    EXPECT_DOUBLE_EQ(moved.tau, 25.0);
+    EXPECT_DOUBLE_EQ(moved.startingRestingLevel, -5.0);
+    // Moved-from source is left in the same valid "unconfigured" state as a
+    // default-constructed NeuralFieldParameters.
+    EXPECT_EQ(source.activationFunction, nullptr); // NOLINT(bugprone-use-after-move)
+}
+
+TEST(NeuralFieldParametersMove, MoveAssignmentTransfersOwnershipWithoutCloning)
+{
+    NeuralFieldParameters source{ 25.0, -5.0, SigmoidFunction{ 2.0, 15.0 } };
+    const ActivationFunction* rawBeforeMove = source.activationFunction.get();
+
+    NeuralFieldParameters dest{ 0.0, 0.0, HeavisideFunction{ 9.0 } };
+    dest = std::move(source);
+
+    EXPECT_EQ(dest.activationFunction.get(), rawBeforeMove);
+    EXPECT_DOUBLE_EQ(dest.tau, 25.0);
+    EXPECT_DOUBLE_EQ(dest.startingRestingLevel, -5.0);
+    EXPECT_EQ(source.activationFunction, nullptr); // NOLINT(bugprone-use-after-move)
+}
+
+TEST(NeuralFieldParametersMove, TypeIsMoveConstructibleAndMoveAssignable)
+{
+    // Guards against a silent regression back to copy-only semantics.
+    EXPECT_TRUE(std::is_move_constructible_v<NeuralFieldParameters>);
+    EXPECT_TRUE(std::is_move_assignable_v<NeuralFieldParameters>);
+}

--- a/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_neural_field.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <algorithm>
 #include <numeric>
+#include <stdexcept>
 
 #include "elements/neural_field.h"
 #include "elements/activation_function.h"
@@ -711,4 +712,47 @@ TEST(NeuralFieldParametersMove, TypeIsMoveConstructibleAndMoveAssignable)
     // Guards against a silent regression back to copy-only semantics.
     EXPECT_TRUE(std::is_move_constructible_v<NeuralFieldParameters>);
     EXPECT_TRUE(std::is_move_assignable_v<NeuralFieldParameters>);
+}
+
+// ---------------------------------------------------------------------------
+// Copy assignment: strong exception guarantee.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    /// Activation function whose clone() always throws, so a failed copy can be
+    /// observed. Everything else is a no-op -- it is never evaluated.
+    struct ThrowingCloneFunction final : ActivationFunction
+    {
+        ThrowingCloneFunction() { type = SIGMOID; }
+
+        std::vector<double> operator()(const std::vector<double>& input) override { return input; }
+        void apply(const std::vector<double>& input, std::vector<double>& out) const override { out = input; }
+        [[nodiscard]] std::unique_ptr<ActivationFunction> clone() const override
+        {
+            throw std::runtime_error("clone failed");
+        }
+        [[nodiscard]] std::string toString() const override { return "throwing"; }
+        void print() const override {}
+    };
+}
+
+TEST(NeuralFieldParametersCopy, FailedCopyAssignmentLeavesDestinationUnchanged)
+{
+    // Copy assignment must give the strong guarantee: if cloning the source's
+    // activation function throws, the destination must be exactly as it was --
+    // not a hybrid holding the source's scalars and its own old function.
+    NeuralFieldParameters source;
+    source.tau = 99.0;
+    source.startingRestingLevel = 42.0;
+    source.activationFunction = std::make_unique<ThrowingCloneFunction>();
+
+    NeuralFieldParameters dest{ 1.0, -2.0, HeavisideFunction{ 9.0 } };
+    const ActivationFunction* destFunctionBefore = dest.activationFunction.get();
+
+    EXPECT_THROW(dest = source, std::runtime_error);
+
+    EXPECT_DOUBLE_EQ(dest.tau, 1.0);
+    EXPECT_DOUBLE_EQ(dest.startingRestingLevel, -2.0);
+    EXPECT_EQ(dest.activationFunction.get(), destFunctionBefore);
 }

--- a/dynamic-neural-field-composer/wiki/Element Reference.md
+++ b/dynamic-neural-field-composer/wiki/Element Reference.md
@@ -34,6 +34,24 @@ NeuralFieldParameters{
 | `HeavisideFunction(x_shift)` | `x_shift=0.0` | Binary threshold function |
 | `AbsSigmoidFunction(x_shift, beta)` | `x_shift=0.0`, `beta=10.0` | Algebraic sigmoid — avoids `exp`; smoother than Heaviside, faster than the exponential sigmoid at very high steepness |
 
+### `NeuralFieldParameters` value semantics
+
+`NeuralFieldParameters` owns its `activationFunction` through a `unique_ptr`, so it defines its
+own copy/move/equality instead of relying on the compiler-generated defaults:
+
+- **`operator==`** compares `tau` and `startingRestingLevel` within a small epsilon, and compares
+  `activationFunction` *by value* — same concrete type (`SigmoidFunction`, `HeavisideFunction`,
+  `AbsSigmoidFunction`) and same parameters — not by pointer identity. Two independently built
+  `NeuralFieldParameters` with equivalent activation functions compare equal.
+- **Copy** (constructor and assignment) deep-clones the source's activation function. If the
+  source's `activationFunction` is `nullptr` (e.g. a default-constructed
+  `NeuralFieldParameters{}`), the copy materializes the default `SigmoidFunction(0, 10)` rather
+  than staying null — a `NeuralField`'s output computation always dereferences its activation
+  function, so a copy can never end up unusable.
+- **Move** (constructor and assignment) transfers the activation function pointer directly (no
+  clone/allocation). The moved-from object is left with `activationFunction == nullptr`, the same
+  valid "unconfigured" state as a default-constructed instance.
+
 ### Components
 
 | Name | Description |


### PR DESCRIPTION
Two related defects on `NeuralFieldParameters`.

**1. Equality compared pointer identity, not value.** `operator==` compared `activationFunction` as a `unique_ptr` address, so two fields with identical sigmoid parameters compared unequal. The activation-function classes define a value `operator==` that was never called.

**2. Rule-of-five violation with inconsistent copy semantics.** The struct declared a copy constructor and copy assignment but no move operations, so moves silently degraded to copies. Worse, the two copy paths disagreed: the copy constructor substituted a default `SigmoidFunction(0,10)` when the source was null, while copy assignment `reset()` to null.

### Which null policy won, and why it matters

The copy constructor's default-substitution turns out to be **load-bearing**, not incidental: `ElementFactory::createElement(NEURAL_FIELD)` constructs a default (null-activation) `NeuralFieldParameters` that reaches `NeuralField` only through the copy constructor, and `NeuralField::calculateOutput()` dereferences `parameters.activationFunction` with no null check.

So the two paths were unified toward the copy constructor's policy, not away from it — copy-assigning a null-activation source now also materialises the default sigmoid instead of resetting to null, which closes a latent null-dereference in `setParameters()`.

### Changes

- `operator==` dispatches through a private `activationFunctionsEqual()`: both-null → equal; one-null → unequal; otherwise it checks the `type` tag *and* `dynamic_cast`s to the concrete class before calling that class's value `operator==`. The type check matters — without it two different activation types carrying the same numbers would wrongly compare equal, and there is a test for exactly that.
- Copy constructor and copy assignment now share one null policy.
- Added defaulted move constructor and move assignment (real pointer transfer, no clone; moved-from left null) and an explicit defaulted destructor for rule-of-five completeness.
- Doxygen documenting the copy/move/null policy and why it is required.
- `wiki/Element Reference.md` gains a "NeuralFieldParameters value semantics" subsection.

### Tests

14 new tests, 6 of which failed before the fix for the intended reasons — including `moved.activationFunction.get()` differing from the pre-move address, proving a clone rather than a move.

Backwards compatible: no public field, layout, or constructor signature changed. Call sites were swept (`element_factory`, `simulation_file_manager`, `element_window`, `node_graph_window`, `simulation_window`) — none compare these parameters with `==`, and none rely on a moved-from object retaining its value.

Full suite: 1108/1110 — the 2 failures are the pre-existing order-dependent `LoggerTest` ones, fixed separately in #140.

Closes #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `NeuralFieldParameters` equality to compare activation functions by type and value.
  * Ensured consistent default handling for null activation functions during copying.
  * Added reliable ownership transfer and safer copy/move behavior.

* **Documentation**
  * Documented parameter equality, copying, and move semantics.

* **Tests**
  * Added regression coverage for equality, copying, null handling, move semantics, and exception safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->