### PR TITLE
fix: throw ELEM_INVALID_SIZE instead of half-constructing an Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `Element`'s constructor logged an error and did a bare `return` when
+  `dimensionParameters.size` was non-positive, leaving `commonParameters` at its default
+  value and `components` completely empty instead of failing to construct. Callers then
+  hit a confusing `ELEM_COMP_NOT_FOUND` from `getComponentPtr("output")`, or saw
+  `getSize() == 0` and had downstream loops silently no-op, rather than learning at
+  construction time that the object was never valid. The constructor now throws
+  `Exception(ErrorCode::ELEM_INVALID_SIZE, ...)` instead, matching the validation
+  `GaussStimulus` already performs for its own parameters (#118)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/elements/element.h
+++ b/dynamic-neural-field-composer/include/elements/element.h
@@ -51,6 +51,11 @@ namespace dnf_composer::element
 	public:
 		/// @brief Construct an element with the given common parameters.
 		/// @param parameters  Name, label, and spatial dimensions.
+		/// @throws Exception(ErrorCode::ELEM_INVALID_SIZE) if parameters.dimensionParameters.size
+		///         is not positive (#118). In normal use ElementDimensions's own constructors
+		///         already reject a non-positive size before it ever reaches here; this guards
+		///         the invariant should dimensionParameters ever be mutated afterward (its
+		///         fields are public) into an invalid state.
 		explicit Element(const ElementCommonParameters& parameters);
 
 		/// @brief Copy commonParameters/components/inputs/outputs; deliberately

--- a/dynamic-neural-field-composer/src/elements/element.cpp
+++ b/dynamic-neural-field-composer/src/elements/element.cpp
@@ -6,11 +6,17 @@ namespace dnf_composer::element
 {
 	Element::Element(const ElementCommonParameters& parameters)
 	{
-		if(parameters.dimensionParameters.size <= 0)
+		// A constructor that cannot establish its invariants must not return a live,
+		// half-built object: components would stay empty and commonParameters would
+		// stay default-constructed, so every caller (getComponentPtr(), getSize(), the
+		// derived-class constructor body that runs right after this one, ...) would
+		// have to defensively re-check something the type is supposed to guarantee.
+		// Throw instead (#118), matching GaussStimulus's own parameter validation.
+		if (parameters.dimensionParameters.size <= 0)
 		{
 			const std::string logMessage = std::format("Element '{}' has an invalid size.", parameters.identifiers.uniqueName);
 			log(tools::logger::LogLevel::ERROR, logMessage);
-			return;
+			throw Exception(ErrorCode::ELEM_INVALID_SIZE, parameters.identifiers.uniqueName);
 		}
 		commonParameters = parameters;
 		components["output"] = std::vector<double>(commonParameters.dimensionParameters.size);

--- a/dynamic-neural-field-composer/tests/elements/test_element.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_element.cpp
@@ -37,6 +37,65 @@ static std::shared_ptr<GaussKernel> makeKernel(const std::string& name, int size
 }
 
 // ---------------------------------------------------------------------------
+// Construction with an invalid size (#118)
+// ---------------------------------------------------------------------------
+//
+// ElementDimensions's own constructors already validate extent/spacing and can never
+// themselves produce size <= 0 (see tests/element_parameters/test_element_parameters.cpp).
+// The only way an Element subclass constructor can still observe an invalid size today is
+// if an already-validated ElementDimensions is mutated afterward (its fields are public)
+// before being wrapped in ElementCommonParameters - reproducing the scenario Element's own
+// defense-in-depth check guards against.
+
+TEST(ElementConstruction, InvalidZeroSizeThrows)
+{
+    ElementDimensions dims{ 100, 1.0 };
+    dims.size = 0;
+    const ElementCommonParameters cp{ "bad", dims };
+    const SigmoidFunction sig{ 0.0, 10.0 };
+    const NeuralFieldParameters nfp{ 25.0, -5.0, sig };
+    EXPECT_THROW(NeuralField(cp, nfp), dnf_composer::Exception);
+}
+
+TEST(ElementConstruction, InvalidNegativeSizeThrows)
+{
+    ElementDimensions dims{ 100, 1.0 };
+    dims.size = -5;
+    const ElementCommonParameters cp{ "bad", dims };
+    EXPECT_THROW(GaussKernel(cp, GaussKernelParameters{}), dnf_composer::Exception);
+}
+
+TEST(ElementConstruction, InvalidSizeThrowsElemInvalidSizeWithElementName)
+{
+    ElementDimensions dims{ 100, 1.0 };
+    dims.size = 0;
+    const ElementCommonParameters cp{ "bad-element", dims };
+    try
+    {
+        NeuralField nf(cp, NeuralFieldParameters{});
+        FAIL() << "Expected Exception to be thrown";
+    }
+    catch (const dnf_composer::Exception& e)
+    {
+        EXPECT_EQ(e.getErrorCode(), ErrorCode::ELEM_INVALID_SIZE);
+        EXPECT_NE(std::string(e.what()).find("bad-element"), std::string::npos);
+    }
+}
+
+TEST(ElementConstruction, InvalidSizeNeverProducesAConstructedObject)
+{
+    // Acceptance criterion: "No code path can observe an Element without its
+    // components." A throwing constructor guarantees this (no object is ever
+    // produced/assigned), verified here through a factory-style call site.
+    ElementDimensions dims{ 100, 1.0 };
+    dims.size = 0;
+    const ElementCommonParameters cp{ "bad", dims };
+    std::shared_ptr<NeuralField> nf;
+    EXPECT_THROW(nf = std::make_shared<NeuralField>(cp, NeuralFieldParameters{}), dnf_composer::Exception);
+    EXPECT_EQ(nf, nullptr);
+}
+
+// ---------------------------------------------------------------------------
 // Identity / metadata
 // ---------------------------------------------------------------------------
 

--- a/dynamic-neural-field-composer/wiki/Troubleshooting.md
+++ b/dynamic-neural-field-composer/wiki/Troubleshooting.md
@@ -68,6 +68,8 @@ Thrown from the `GaussStimulus`/`GaussStimulus2D`/`TimedGaussStimulus`/`TimedGau
 
 `ErrorCode::ELEM_INVALID_SIZE`, thrown e.g. from `Collapse`/`Expand` when the configured dimensions are inconsistent with the axis being kept/broadcast. Double-check that a `Collapse`'s own (1D) output size matches the kept axis of its `inputDimensions`, and that an `Expand`'s profile-axis size matches its 1D input's size — see [Element Reference → Collapse](Element-Reference#collapse) and [→ Expand](Element-Reference#expand).
 
+It is also thrown directly from the base `Element` constructor (so from **any** element type, not just `Collapse`/`Expand`) if `ElementCommonParameters.dimensionParameters.size` is not positive. In practice this can only happen if an `ElementDimensions` that was already validated at construction is mutated afterward (its fields are public) into an invalid state before being handed to an element's constructor — `ElementDimensions`'s own constructors already reject a non-positive extent/step/sample-count, so a size `<= 0` can no longer be produced through them. Previously this path logged an `ERROR` and silently produced a broken element (empty `components`, so `getComponentPtr("output")` failed with a confusing `ELEM_COMP_NOT_FOUND` later, or `getSize()` returned `0` and downstream loops silently no-op); the constructor now fails loudly at the point of construction instead.
+
 ### `ERROR`: "Input '...' has a different size than '...'."
 
 Logged (not thrown) from `Element::addInput()` at `ERROR` level when you connect two elements whose component sizes don't match — the connection is silently rejected (`addInput` returns without throwing, so check your console/log output if a wire-up seems to have no effect).


### PR DESCRIPTION
```cpp
// element.cpp
if (parameters.dimensionParameters.size <= 0) {
    log(... "invalid size.");
    return;                    // commonParameters default, components left empty
}
```

On an invalid size the constructor logged and returned, leaving the object half-built. Callers then hit a confusing `ELEM_COMP_NOT_FOUND` from `getComponentPtr("output")`, or got `getSize() == 0` and silently no-op'd downstream. A constructor that cannot establish its invariants must throw — `ELEM_INVALID_SIZE` already exists, and `GaussStimulus` already does this correctly.

It now throws, keeping the existing log line.

### Call-site sweep

Because this converts silent degradation into a throw, every path that constructs an element was checked:

- Nothing in `src/`, `include/` or `examples/` mutates `.size`/`.size_x`/`.size_y`/`.x_max`/`.y_max` after an `ElementDimensions` is built, so the only way to reach this branch is by mutating those public fields directly — which is exactly how the new tests reproduce it.
- GUI creation paths always construct through `ElementDimensions`'s validating constructors, so a 0/negative value from the UI already throws there (since #96) and never reaches this branch.
- `simulation_file_manager` rejects non-positive `x_max`/`d_x` up front (#39).
- No existing test asserted the old log-and-degrade behaviour, so nothing had to be weakened.

In other words this is a defensive backstop on an already-validated path, not a behaviour change for any current caller.

Two pre-existing issues found during that sweep are **not** touched here and are filed separately as #146: the GUI creation sites have no `try`/`catch` for the exceptions the library now throws, and `simulation_file_manager` pre-checks `x_max` but not `y_max`.

### Tests

4 new tests, all failing before the fix with `Expected: ... throws an exception of type dnf_composer::Exception. Actual: it throws nothing.` — zero size throws, negative size throws, the exception carries `ELEM_INVALID_SIZE` and the element name, and a `make_shared` call site never yields a non-null half-built object.

Docs: `@throws` Doxygen on the constructor, and the `ELEM_INVALID_SIZE` entry in `wiki/Troubleshooting.md` extended to cover this path.

Full suite: 1100/1102 — the 2 failures are the pre-existing order-dependent `LoggerTest` ones, fixed separately in #140.

Closes #118
