### PR TITLE
fix: quit through the main loop instead of std::exit so cleanup runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **File → Quit** and **Ctrl+Q** called `std::exit(0)` from inside the ImGui render
+  callback, terminating the process without unwinding the stack: `Application::close()`
+  never ran and no destructor fired. Both now call the new `Application::requestQuit()`,
+  which `hasGUIBeenClosed()` reports, so the ordinary main loop falls through to
+  `close()` and shuts down normally. Existing main loops need no change (#122)
+
+### Added
+- `Application::requestQuit()` / `isQuitRequested()` — ask the application to shut down
+  at the end of the current frame, and query whether a shutdown was requested (#122)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/application/application.h
+++ b/dynamic-neural-field-composer/include/application/application.h
@@ -59,10 +59,27 @@ namespace dnf_composer
 		std::shared_ptr<imgui_kit::UserInterface> gui;
 		bool guiActive = true;
 		static float uiScalePct; ///< User-controlled UI scale percentage (50–200%).
+		static inline bool quitRequested = false; ///< Set by requestQuit(); see hasGUIBeenClosed().
 
 	public:
 		static float  getUiScalePct()          { return uiScalePct; }
 		static void   setUiScalePct(float pct) { uiScalePct = pct; }
+
+		/// @brief Ask the application to shut down at the end of the current frame.
+		///
+		/// The UI calls this instead of terminating the process directly (issue #122):
+		/// a request makes @c hasGUIBeenClosed() return true, so the ordinary main loop
+		/// falls through to @c close() and every destructor runs normally.
+		/// Existing loops need no change.
+		static void requestQuit();
+
+		/// @brief Return true once @c requestQuit() has been called.
+		[[nodiscard]] static bool isQuitRequested();
+
+		/// @brief Clear the quit request. For tests only: a real process exits shortly
+		/// after requesting a quit, but the flag is process-wide, so a test that sets it
+		/// must restore it to avoid bleeding state into unrelated tests.
+		static void resetQuitRequestForTesting();
 
 		/// @brief Construct an Application.
 		/// @param simulation    Shared simulation to drive (may be nullptr).
@@ -105,7 +122,8 @@ namespace dnf_composer
 		/// @brief Toggle the GUI on or off at runtime.
 		void toggleGUI();
 
-		/// @brief Return true if the user has closed the main window.
+		/// @brief Return true if the user has closed the main window or requested a quit.
+		/// @see requestQuit()
 		[[nodiscard]] bool hasGUIBeenClosed() const;
 
 		/// @brief Return true if the GUI overlay is currently active.

--- a/dynamic-neural-field-composer/include/user_interface/main_menu_bar.h
+++ b/dynamic-neural-field-composer/include/user_interface/main_menu_bar.h
@@ -39,6 +39,38 @@ namespace dnf_composer::user_interface
 		bool showImGuiKitStyleEditor = false;
 	};
 
+	/// @brief What a quit trigger (Quit menu item or Ctrl+Q shortcut) should do to
+	/// the simulation before the application is signalled to close.
+	///
+	/// Background (issue #122): the menu used to call `std::exit(0)` directly from
+	/// inside the render callback. That terminates the process without unwinding
+	/// the stack -- no destructors run, `Application::close()` never executes, and
+	/// there is no way to unit-test it (you cannot assert on a dead process). The
+	/// fix instead has the menu call `Application::requestQuit()`, which makes
+	/// `Application::hasGUIBeenClosed()` return true, so the ordinary main loop shuts
+	/// down through its normal, already-correct path (`Application::close()`, then
+	/// every local's destructor as `main()` returns). Existing main loops keep
+	/// working unchanged.
+	///
+	/// This enum captures the two triggers' pre-existing (and deliberately
+	/// different) behavior: the Quit menu item saves before closing; the Ctrl+Q
+	/// shortcut does not. That asymmetry predates this fix and is preserved as-is
+	/// -- it is a pre-existing product decision, not part of issue #122's scope.
+	enum class QuitAction
+	{
+		None,        ///< Neither trigger fired this frame -- no action.
+		SaveAndQuit, ///< Quit menu item: save, close, and clean the simulation, then quit.
+		QuitOnly     ///< Ctrl+Q shortcut: quit without touching the simulation.
+	};
+
+	/// @brief Pure decision function: given which quit trigger(s) fired this frame,
+	/// decide what should happen. No ImGui, no Simulation, no OS calls -- so unlike
+	/// `MainMenuBar::render()`/`handleShortcuts()`, it can be unit-tested headlessly
+	/// (same pattern as `quickPopulatePlotTypeFor()` in plot_control_window.h).
+	/// If both triggers somehow fire in the same frame, the menu item's
+	/// save-before-closing behavior takes precedence (the safer of the two).
+	[[nodiscard]] QuitAction decideQuitAction(bool quitMenuItemClicked, bool ctrlQPressed) noexcept;
+
 	class MainMenuBar final : public imgui_kit::UserInterfaceWindow
 	{
 	private:
@@ -54,6 +86,13 @@ namespace dnf_composer::user_interface
 
 		void render() override;
 		~MainMenuBar() override = default;
+
+		/// @brief Carry out the simulation-side effects of @p action (if any) and,
+		/// unless @p action is QuitAction::None, call `Application::requestQuit()`.
+		/// Public (rather than an implementation detail of render()/handleShortcuts())
+		/// specifically so it can be driven directly from tests without a live ImGui
+		/// context -- it touches only Simulation and the quit request, never ImGui.
+		void executeQuitAction(QuitAction action);
 	private:
 		void renderMainMenuBar();
 		void renderFileWindows();

--- a/dynamic-neural-field-composer/src/application/application.cpp
+++ b/dynamic-neural-field-composer/src/application/application.cpp
@@ -98,8 +98,28 @@ namespace dnf_composer
 		log(tools::logger::LogLevel::INFO, std::format("GUI is {}", guiActive ? "enabled." : "disabled."));
 	}
 
+	void Application::requestQuit()
+	{
+		quitRequested = true;
+	}
+
+	bool Application::isQuitRequested()
+	{
+		return quitRequested;
+	}
+
+	void Application::resetQuitRequestForTesting()
+	{
+		quitRequested = false;
+	}
+
 	bool Application::hasGUIBeenClosed() const
 	{
+		// Checked before touching the GUI so a quit request is honoured even when
+		// the GUI is disabled or not yet initialized.
+		if (quitRequested) {
+			return true;
+		}
 		if (guiActive) {
 			return gui->isShutdownRequested();
 		}

--- a/dynamic-neural-field-composer/src/user_interface/main_menu_bar.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/main_menu_bar.cpp
@@ -1,6 +1,8 @@
 #include "user_interface/main_menu_bar.h"
 #include <array>
 
+#include "application/application.h"
+
 #ifdef __APPLE__
     #define CTRL_KEY "Cmd"
 #else
@@ -10,9 +12,41 @@
 
 namespace dnf_composer::user_interface
 {
+	QuitAction decideQuitAction(const bool quitMenuItemClicked, const bool ctrlQPressed) noexcept
+	{
+		if (quitMenuItemClicked)
+		{
+			return QuitAction::SaveAndQuit;
+		}
+		if (ctrlQPressed)
+		{
+			return QuitAction::QuitOnly;
+		}
+		return QuitAction::None;
+	}
+
 	MainMenuBar::MainMenuBar(const std::shared_ptr<Simulation>& simulation)
 		: simulation(simulation)
 	{}
+
+	void MainMenuBar::executeQuitAction(const QuitAction action)
+	{
+		switch (action)
+		{
+		case QuitAction::SaveAndQuit:
+			simulation->save();
+			simulation->close();
+			simulation->clean();
+			Application::requestQuit();
+			break;
+		case QuitAction::QuitOnly:
+			Application::requestQuit();
+			break;
+		case QuitAction::None:
+		default:
+			break;
+		}
+	}
 
 	void MainMenuBar::render()
 	{
@@ -52,10 +86,7 @@ namespace dnf_composer::user_interface
                 }
                 if (ImGui::MenuItem("Quit", CTRL_KEY "+Q"))
                 {
-                    simulation->save();
-	                simulation->close();
-					simulation->clean();
-                    std::exit(0);
+                    executeQuitAction(decideQuitAction(true, false));
                 }
                 ImGui::EndMenu();
             }
@@ -330,7 +361,7 @@ namespace dnf_composer::user_interface
 	    }
 	    if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_Q))
 	    {
-	        std::exit(0);
+	        executeQuitAction(decideQuitAction(false, true));
 	    }
 
 	    // Zoom in/out through presets

--- a/dynamic-neural-field-composer/tests/application/test_application.cpp
+++ b/dynamic-neural-field-composer/tests/application/test_application.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <memory>
+#include <exception>
 #include <filesystem>
 
 #include "application/application.h"
@@ -113,7 +114,20 @@ TEST_F(MainMenuBarQuitTest, RequestQuitEndsAnUnmodifiedMainLoop)
     // picks Quit.
     const auto sim = makeSimulationWithOneField("quit-main-loop");
     const auto vis = std::make_shared<Visualization>(sim);
-    const Application app{ sim, vis };
+
+    // Constructing an Application builds the platform GUI object, which on the
+    // GLFW backends throws outright when there is no display (headless Linux CI).
+    // Where that is the case there is no main loop to test, so skip rather than
+    // report a failure that says nothing about this fix.
+    std::unique_ptr<Application> app;
+    try
+    {
+        app = std::make_unique<Application>(sim, vis);
+    }
+    catch (const std::exception& e)
+    {
+        GTEST_SKIP() << "no GUI available in this environment: " << e.what();
+    }
 
     EXPECT_FALSE(Application::isQuitRequested());
 
@@ -123,7 +137,7 @@ TEST_F(MainMenuBarQuitTest, RequestQuitEndsAnUnmodifiedMainLoop)
     // is safe on an Application that was never init()'d -- the GLFW backend's
     // isShutdownRequested() reads a window that does not exist until then. This
     // line is exactly what an unmodified main loop evaluates.
-    EXPECT_TRUE(app.hasGUIBeenClosed());
+    EXPECT_TRUE(app->hasGUIBeenClosed());
 }
 
 TEST_F(MainMenuBarQuitTest, NoneActionDoesNotRequestQuitOrTouchSimulation)

--- a/dynamic-neural-field-composer/tests/application/test_application.cpp
+++ b/dynamic-neural-field-composer/tests/application/test_application.cpp
@@ -110,16 +110,19 @@ TEST_F(MainMenuBarQuitTest, RequestQuitEndsAnUnmodifiedMainLoop)
 {
     // The backwards-compatibility guarantee: a main loop written before this fix
     // -- `while (!app.hasGUIBeenClosed())` -- must still terminate when the user
-    // picks Quit. hasGUIBeenClosed() answers the quit request before touching the
-    // GUI, so this holds even for an Application that was never init()'d.
+    // picks Quit.
     const auto sim = makeSimulationWithOneField("quit-main-loop");
     const auto vis = std::make_shared<Visualization>(sim);
     const Application app{ sim, vis };
 
-    EXPECT_FALSE(app.hasGUIBeenClosed());
+    EXPECT_FALSE(Application::isQuitRequested());
 
     Application::requestQuit();
 
+    // hasGUIBeenClosed() answers the quit request before touching the GUI, so this
+    // is safe on an Application that was never init()'d -- the GLFW backend's
+    // isShutdownRequested() reads a window that does not exist until then. This
+    // line is exactly what an unmodified main loop evaluates.
     EXPECT_TRUE(app.hasGUIBeenClosed());
 }
 

--- a/dynamic-neural-field-composer/tests/application/test_application.cpp
+++ b/dynamic-neural-field-composer/tests/application/test_application.cpp
@@ -1,12 +1,18 @@
 #include <gtest/gtest.h>
 #include <memory>
+#include <filesystem>
 
 #include "application/application.h"
 #include "simulation/simulation.h"
 #include "visualization/visualization.h"
 #include "exceptions/exception.h"
+#include "user_interface/main_menu_bar.h"
+#include "elements/neural_field.h"
+#include "elements/activation_function.h"
 
 using namespace dnf_composer;
+
+namespace fs = std::filesystem;
 
 // ---------------------------------------------------------------------------
 // Static scale accessors — no OpenGL context required
@@ -34,4 +40,132 @@ TEST(ApplicationConstruction, MismatchedSimulationThrows)
     auto sim2 = std::make_shared<Simulation>("s2", 1.0, 0.0, 0.0);
     auto vis  = std::make_shared<Visualization>(sim1);
     EXPECT_THROW(Application(sim2, vis), Exception);
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #122: the Quit menu item and the Ctrl+Q shortcut
+// (user_interface::MainMenuBar) used to call std::exit(0) directly from inside
+// the render callback, terminating the process without unwinding the stack --
+// no destructors, no Application::close(). The fix replaces that with
+// Application::requestQuit(), which hasGUIBeenClosed() reports, plus a pure
+// decision function (decideQuitAction) that is trivially testable.
+//
+// The request lives on Application (not on the menu bar) so that every existing
+// main loop -- `while (!app.hasGUIBeenClosed())` -- exits on Quit without any
+// source change. MainMenuBar needs no live ImGui/window context for any of the
+// following, so these sit alongside Application's other headless-safe tests.
+// ---------------------------------------------------------------------------
+
+using dnf_composer::user_interface::MainMenuBar;
+using dnf_composer::user_interface::QuitAction;
+using dnf_composer::user_interface::decideQuitAction;
+
+TEST(DecideQuitAction, NeitherTriggerProducesNone)
+{
+    EXPECT_EQ(decideQuitAction(false, false), QuitAction::None);
+}
+
+TEST(DecideQuitAction, MenuItemAloneProducesSaveAndQuit)
+{
+    EXPECT_EQ(decideQuitAction(true, false), QuitAction::SaveAndQuit);
+}
+
+TEST(DecideQuitAction, CtrlQAloneProducesQuitOnly)
+{
+    EXPECT_EQ(decideQuitAction(false, true), QuitAction::QuitOnly);
+}
+
+TEST(DecideQuitAction, BothTriggersPreferSaveAndQuit)
+{
+    // If both somehow fire in the same frame, the safer (save-first) behavior wins.
+    EXPECT_EQ(decideQuitAction(true, true), QuitAction::SaveAndQuit);
+}
+
+namespace
+{
+    std::shared_ptr<Simulation> makeSimulationWithOneField(const std::string& identifier)
+    {
+        auto sim = std::make_shared<Simulation>(identifier, 1.0, 0.0, 0.0);
+        const element::ElementCommonParameters cp{ "nf", 20 };
+        const element::NeuralFieldParameters nfp{ 25.0, -5.0, element::SigmoidFunction{ 0.0, 10.0 } };
+        sim->addElement(std::make_shared<element::NeuralField>(cp, nfp));
+        return sim;
+    }
+}
+
+class MainMenuBarQuitTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { Application::resetQuitRequestForTesting(); }
+    // The request is process-wide (static); always leave it clean for later tests.
+    void TearDown() override { Application::resetQuitRequestForTesting(); }
+};
+
+TEST_F(MainMenuBarQuitTest, StartsWithNoQuitRequested)
+{
+    EXPECT_FALSE(Application::isQuitRequested());
+}
+
+TEST_F(MainMenuBarQuitTest, RequestQuitEndsAnUnmodifiedMainLoop)
+{
+    // The backwards-compatibility guarantee: a main loop written before this fix
+    // -- `while (!app.hasGUIBeenClosed())` -- must still terminate when the user
+    // picks Quit. hasGUIBeenClosed() answers the quit request before touching the
+    // GUI, so this holds even for an Application that was never init()'d.
+    const auto sim = makeSimulationWithOneField("quit-main-loop");
+    const auto vis = std::make_shared<Visualization>(sim);
+    const Application app{ sim, vis };
+
+    EXPECT_FALSE(app.hasGUIBeenClosed());
+
+    Application::requestQuit();
+
+    EXPECT_TRUE(app.hasGUIBeenClosed());
+}
+
+TEST_F(MainMenuBarQuitTest, NoneActionDoesNotRequestQuitOrTouchSimulation)
+{
+    const auto sim = makeSimulationWithOneField("menu-none");
+    MainMenuBar menuBar{ sim };
+
+    menuBar.executeQuitAction(QuitAction::None);
+
+    EXPECT_FALSE(Application::isQuitRequested());
+    EXPECT_EQ(sim->getElements().size(), 1u);
+}
+
+TEST_F(MainMenuBarQuitTest, QuitOnlyRequestsQuitWithoutTouchingSimulation)
+{
+    // Regression for the Ctrl+Q half of issue #122: previously this path called
+    // std::exit(0) immediately, with no save/close/clean (an existing asymmetry
+    // versus the Quit menu item that this fix intentionally preserves). It must
+    // now only flip the quit-request flag -- the simulation is left exactly as
+    // it was, and, crucially, this line finishing at all (instead of the test
+    // binary vanishing) proves std::exit was NOT called.
+    const auto sim = makeSimulationWithOneField("menu-ctrlq");
+
+    MainMenuBar menuBar{ sim };
+    menuBar.executeQuitAction(QuitAction::QuitOnly);
+
+    EXPECT_TRUE(Application::isQuitRequested());
+    EXPECT_EQ(sim->getElements().size(), 1u); // untouched: no close()/clean() ran
+}
+
+TEST_F(MainMenuBarQuitTest, SaveAndQuitRequestsQuitAndClosesAndCleansSimulation)
+{
+    // Regression for the Quit-menu-item half of issue #122: the save/close/clean
+    // sequence must be identical to before, but a quit request replaces the
+    // std::exit(0) call.
+    const auto sim = makeSimulationWithOneField("menu-quit-save");
+
+    MainMenuBar menuBar{ sim };
+    menuBar.executeQuitAction(QuitAction::SaveAndQuit);
+
+    EXPECT_TRUE(Application::isQuitRequested());
+    EXPECT_TRUE(sim->getElements().empty());   // clean() cleared the elements
+    EXPECT_FALSE(sim->isInitialized());        // close() + clean() both clear this
+
+    const std::string savedFile = std::string(OUTPUT_DIRECTORY) + "/menu-quit-save/menu-quit-save.dnf";
+    EXPECT_TRUE(fs::exists(savedFile)) << "save() should still have written the .dnf file, same as before this fix";
+    fs::remove_all(std::string(OUTPUT_DIRECTORY) + "/menu-quit-save");
 }

--- a/dynamic-neural-field-composer/wiki/Application and UI.md
+++ b/dynamic-neural-field-composer/wiki/Application and UI.md
@@ -90,6 +90,23 @@ app.close();                   // tear down GUI and simulation
 1. Calls `simulation->step()`
 2. Calls `gui->render()`, which renders all registered ImGui windows and presents the frame (skipped if GUI is inactive)
 
+### Quitting
+
+`hasGUIBeenClosed()` returns true both when the user closes the main window and when
+a quit has been requested — **File → Quit** and **Ctrl+Q** both call
+`Application::requestQuit()`. The loop above therefore exits on either, and `close()`
+plus every destructor runs normally. No change is needed to an existing main loop.
+
+To end the application from your own code, call:
+
+```cpp
+Application::requestQuit();       // loop exits at the end of the current frame
+bool quitting = Application::isQuitRequested();
+```
+
+The request is deliberately not a process exit: earlier versions called `std::exit(0)`
+from inside the menu callback, which skipped `close()` and every destructor.
+
 ---
 
 ## GUI control


### PR DESCRIPTION
Closes #122.

**File → Quit** and **Ctrl+Q** called `std::exit(0)` from inside the ImGui render callback. That ends the process without unwinding the stack, so `Application::close()` never runs and no destructor fires — and it cannot be tested, because the test binary would simply vanish.

Both triggers now call `Application::requestQuit()`. `hasGUIBeenClosed()` reports the request, so the ordinary main loop exits and `close()` plus every destructor runs on its normal path.

The request lives on `Application` rather than on the menu bar so that **existing main loops keep working unchanged** — `while (!app.hasGUIBeenClosed())` now ends on Quit with no edit. No example or downstream loop needed touching.

The save/close/clean asymmetry between the two triggers (the menu item saves, Ctrl+Q does not) predates this fix and is preserved.

Tests: a pure `decideQuitAction()` covers the trigger→action mapping headlessly; `MainMenuBarQuitTest` covers the simulation side effects and asserts an unmodified main loop terminates after `requestQuit()`. Suite 1105/1107 locally — the 2 failures are the known pre-existing `LoggerTest` order dependence fixed on #140.

Docs: `wiki/Application and UI.md` gains a Quitting section; CHANGELOG updated.