### PR TITLE
fix: bounds-check heatmap manual dimensions and circular-vector indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Two unguarded out-of-bounds reads (#121). A heatmap in manual-dimension mode
+  computed `rows = y_max / y_step`, `cols = x_max / x_step` from user-editable axis
+  fields and handed `rows * cols` to `ImPlot::PlotHeatmap` with no check against the
+  actual data size, so a mismatched setting read past the buffer; columns are now
+  clamped so `rows * cols` fits the data (rows, and the configured aspect ratio, are
+  preserved) and a warning is logged on change. `obtainCircularVector` /
+  `obtainCircularVector_into` indexed `contents[indices[i] - 1]` with no check, so an
+  index of `0` read `contents[-1]`; both now validate the whole index set once per
+  call — off the per-element copy loop, to keep the convolution hot path
+  vectorizable — and return zeros with a logged error instead of reading out of bounds
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/tools/math.h
+++ b/dynamic-neural-field-composer/include/tools/math.h
@@ -211,10 +211,41 @@ namespace dnf_composer::tools::math
 		}
 	}
 
+	/// @brief Gather @p contents at 1-based @p indices into @p out (circular extension helper).
+	///
+	/// @p indices are 1-based (a value of 1 selects `contents[0]`), as produced by
+	/// `createExtendedIndex()`. @p out must already be sized to `indices.size()`
+	/// (all current call sites pre-size a scratch buffer once in `init()`).
+	///
+	/// This sits on the convolution hot path (see the separable 2D pass around
+	/// `conv2d_separable`, and the per-step kernel elements that call it every
+	/// simulation tick), tuned for SIMD/auto-vectorization by #107. To avoid
+	/// putting a branch inside that tight copy loop, the whole index set is
+	/// validated **once, up front** (a single O(n) pass) instead of per element.
+	/// In intended usage `indices` come from `createExtendedIndex()` /
+	/// `computeKernelRange()` (which clamps the kernel range to at most half the
+	/// field size), so they are within `[1, contents.size()]` by construction;
+	/// this guard defends that invariant — e.g. against a stale `extIndex_x/y`
+	/// reused after the field was resized — instead of silently reading
+	/// `contents[-1]` or past the end (#121). On violation, logs an error and
+	/// fills @p out with `T()` rather than touching out-of-bounds memory.
 	template<typename T>
 	void obtainCircularVector_into(std::vector<T>& out, const std::vector<int>& indices,
 	                               const std::vector<T>& contents)
 	{
+		const std::size_t size = contents.size();
+		const bool allInRange = std::ranges::all_of(indices,
+			[size](int idx) { return idx >= 1 && static_cast<std::size_t>(idx) <= size; });
+
+		if (!allInRange) [[unlikely]]
+		{
+			logger::log(logger::LogLevel::ERROR,
+				"obtainCircularVector_into: index outside the valid 1.." + std::to_string(size) +
+				" range for contents; returning zeros to avoid an out-of-bounds read.");
+			std::ranges::fill(out, T());
+			return;
+		}
+
 		for (int i = 0; i < static_cast<int>(indices.size()); ++i) {
 			out[i] = contents[indices[i] - 1];
 }
@@ -349,10 +380,31 @@ namespace dnf_composer::tools::math
 		return derivative;
 	}
 
+	/// @brief Gather @p contents at 1-based @p indices into a newly-allocated vector.
+	///
+	/// Same circular-extension gather as obtainCircularVector_into(), returning a
+	/// fresh vector instead of writing into a caller-owned scratch buffer. See
+	/// obtainCircularVector_into() for the indexing convention, the hot-path
+	/// perf rationale for validating @p indices once up front rather than per
+	/// element, and the (#121) bounds-check background. On an out-of-range
+	/// index, logs an error and returns a zero-filled vector instead of reading
+	/// out of bounds.
 	template<typename T>
 	std::vector<T> obtainCircularVector(const std::vector<int>& indices, const std::vector<T>& contents)
 	{
 		std::vector<T> newContents(indices.size());
+		const std::size_t size = contents.size();
+		const bool allInRange = std::ranges::all_of(indices,
+			[size](int idx) { return idx >= 1 && static_cast<std::size_t>(idx) <= size; });
+
+		if (!allInRange) [[unlikely]]
+		{
+			logger::log(logger::LogLevel::ERROR,
+				"obtainCircularVector: index outside the valid 1.." + std::to_string(size) +
+				" range for contents; returning zeros to avoid an out-of-bounds read.");
+			return newContents; // value-initialized to T() already
+		}
+
 		for (int i = 0; i < indices.size(); i++) {
 			newContents[i] = contents[indices[i] - 1];
 }

--- a/dynamic-neural-field-composer/include/visualization/heatmap.h
+++ b/dynamic-neural-field-composer/include/visualization/heatmap.h
@@ -1,9 +1,44 @@
 #pragma once
 
+#include <cstddef>
+#include <utility>
+
 #include "plot.h"
 
 namespace dnf_composer
 {
+	/// @brief Compute the row/column grid for manual (non-auto) heatmap dimensions.
+	///
+	/// In manual mode, Heatmap::render() derives the grid from user-editable axis
+	/// extents and step sizes: `rows = y_max / y_step`, `cols = x_max / x_step`.
+	/// Those fields have no built-in relationship to the actual data buffer
+	/// size, so a mismatched combination (e.g. a step too small, or maxes too
+	/// large for the connected element) previously asked
+	/// `ImPlot::PlotHeatmap(..., rows, cols, ...)` to read `rows * cols`
+	/// elements from a buffer that holds fewer — an out-of-bounds read (#121).
+	///
+	/// This computes the same naive rows/cols and then clamps @c cols down
+	/// (preserving @p rows, and therefore the aspect ratio the user configured)
+	/// until `rows * cols <= dataSize`. A non-positive step yields 0 for that
+	/// axis, which is degenerate but never out of bounds.
+	///
+	/// It is deliberately pure and silent: it is called from a render function
+	/// that runs every frame, so reporting a clamp is the caller's decision
+	/// (see @c clamped) rather than a log line emitted 60 times a second.
+	struct ManualHeatmapDimensions
+	{
+		int rows;     ///< Rows to pass to ImPlot::PlotHeatmap.
+		int cols;     ///< Columns to pass, already clamped to fit @c dataSize.
+		bool clamped; ///< True if @c cols was reduced to fit the available data.
+	};
+
+	/// @param x_max,y_max  Axis extents (the heatmap "max" dimension fields).
+	/// @param x_step,y_step Axis step sizes.
+	/// @param dataSize     Number of elements actually available in the flattened data.
+	/// @return rows/cols such that `rows * cols <= dataSize` (both >= 0).
+	[[nodiscard]] ManualHeatmapDimensions resolveManualHeatmapDimensions(int x_max, int y_max,
+		float x_step, float y_step, std::size_t dataSize);
+
 	struct HeatmapParameters final : PlotSpecificParameters
 	{
 		double scaleMin, scaleMax;
@@ -21,6 +56,9 @@ namespace dnf_composer
 	class Heatmap : public Plot
 	{
 		HeatmapParameters heatmapParameters;
+		/// Last column count reported as clamped, so render() warns once per change
+		/// instead of once per frame. -1 means "nothing reported yet".
+		int lastReportedClampedCols = -1;
 	public:
 		explicit Heatmap(const PlotCommonParameters& parameters =
 		                 { PlotType::HEATMAP,

--- a/dynamic-neural-field-composer/src/visualization/heatmap.cpp
+++ b/dynamic-neural-field-composer/src/visualization/heatmap.cpp
@@ -1,10 +1,35 @@
 #include "visualization/heatmap.h"
+#include <algorithm>
 #include <array>
 #include <cmath>
+#include <string>
 #include <utility>
 
 namespace dnf_composer
 {
+	ManualHeatmapDimensions resolveManualHeatmapDimensions(int x_max, int y_max,
+		float x_step, float y_step, std::size_t dataSize)
+	{
+		int rows = (y_step > 0.0F) ? static_cast<int>(static_cast<float>(y_max) / y_step) : 0;
+		int cols = (x_step > 0.0F) ? static_cast<int>(static_cast<float>(x_max) / x_step) : 0;
+		if (rows < 0) { rows = 0; }
+		if (cols < 0) { cols = 0; }
+
+		if (dataSize == 0)
+		{
+			return { 0, 0, false };
+		}
+
+		// Compare via division, not rows*cols, to avoid a multiplication overflow
+		// for pathological inputs.
+		if (rows > 0 && static_cast<std::size_t>(cols) > dataSize / static_cast<std::size_t>(rows))
+		{
+			return { rows, static_cast<int>(dataSize / static_cast<std::size_t>(rows)), true };
+		}
+
+		return { rows, cols, false };
+	}
+
 	HeatmapParameters::HeatmapParameters()
 		: scaleMin(0), scaleMax(1), autoScale(true), autoDimensions(true)
 	{}
@@ -227,8 +252,27 @@ namespace dnf_composer
 		}
 		else
 		{
-			rows = static_cast<int>(static_cast<float>(y_max) / y_step);
-			cols = static_cast<int>(static_cast<float>(x_max) / x_step);
+			const auto manualDims = resolveManualHeatmapDimensions(
+				x_max, y_max, x_step, y_step, flattened_matrix->size());
+			rows = manualDims.rows;
+			cols = manualDims.cols;
+
+			// render() runs every frame, so warn only when the clamp changes.
+			if (manualDims.clamped)
+			{
+				if (cols != lastReportedClampedCols)
+				{
+					log(tools::logger::LogLevel::WARNING,
+						"Heatmap: manual dimensions exceed the available data (" +
+						std::to_string(flattened_matrix->size()) + " elements); clamping columns to " +
+						std::to_string(cols) + " to avoid an out-of-bounds read.");
+					lastReportedClampedCols = cols;
+				}
+			}
+			else
+			{
+				lastReportedClampedCols = -1;
+			}
 		}
 
 		static constexpr ImPlotFlags hm_flags = ImPlotFlags_Crosshairs | ImPlotFlags_NoLegend;

--- a/dynamic-neural-field-composer/tests/CMakeLists.txt
+++ b/dynamic-neural-field-composer/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "exceptions/test_exception.cpp"
             # visualization
             "visualization/test_visualization.cpp"
+            "visualization/test_heatmap_dimensions.cpp"
             # user_interface
             "user_interface/test_plot_control_window.cpp"
             "visualization/test_plot_parameters.cpp"

--- a/dynamic-neural-field-composer/tests/tools/test_math.cpp
+++ b/dynamic-neural-field-composer/tests/tools/test_math.cpp
@@ -1438,3 +1438,82 @@ TEST(SeedNormal, DifferentSeedDifferentSequence)
         if (a[i] != b[i]) { anyDifferent = true; break; }
     EXPECT_TRUE(anyDifferent);
 }
+
+// ---------------------------------------------------------------------------
+// obtainCircularVector / obtainCircularVector_into — issue #121
+//
+// Both do `contents[indices[i] - 1]` (1-based indices) with no bounds check.
+// An index of 0 reads contents[-1]; an index > contents.size() reads past the
+// end. Both are on the convolution hot path (conv2d_separable, and every
+// circular 1D kernel element's step()), so the fix validates the whole index
+// set once per call rather than branching per element inside the copy loop —
+// see the Doxygen on both functions in tools/math.h for the perf rationale.
+// ---------------------------------------------------------------------------
+
+TEST(ObtainCircularVector, InRangeIndicesGatherCorrectly)
+{
+    const std::vector<int> indices{ 1, 3, 2 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    const auto result = obtainCircularVector(indices, contents);
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_DOUBLE_EQ(result[0], 10.0);
+    EXPECT_DOUBLE_EQ(result[1], 30.0);
+    EXPECT_DOUBLE_EQ(result[2], 20.0);
+}
+
+TEST(ObtainCircularVector, ZeroIndexDoesNotReadOutOfBounds)
+{
+    // index 0 is invalid for a 1-based scheme: contents[0 - 1] == contents[-1].
+    const std::vector<int> indices{ 0, 1, 2 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    const auto result = obtainCircularVector(indices, contents);
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_DOUBLE_EQ(result[0], 0.0);
+    EXPECT_DOUBLE_EQ(result[1], 0.0);
+    EXPECT_DOUBLE_EQ(result[2], 0.0);
+}
+
+TEST(ObtainCircularVector, TooLargeIndexDoesNotReadOutOfBounds)
+{
+    // contents.size() == 3, so a 1-based index of 10 is out of range.
+    const std::vector<int> indices{ 1, 2, 10 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    const auto result = obtainCircularVector(indices, contents);
+    ASSERT_EQ(result.size(), 3u);
+    EXPECT_DOUBLE_EQ(result[0], 0.0);
+    EXPECT_DOUBLE_EQ(result[1], 0.0);
+    EXPECT_DOUBLE_EQ(result[2], 0.0);
+}
+
+TEST(ObtainCircularVectorInto, InRangeIndicesGatherCorrectly)
+{
+    std::vector<double> out(3, -1.0);
+    const std::vector<int> indices{ 1, 3, 2 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    obtainCircularVector_into(out, indices, contents);
+    EXPECT_DOUBLE_EQ(out[0], 10.0);
+    EXPECT_DOUBLE_EQ(out[1], 30.0);
+    EXPECT_DOUBLE_EQ(out[2], 20.0);
+}
+
+TEST(ObtainCircularVectorInto, ZeroIndexDoesNotReadOutOfBounds)
+{
+    std::vector<double> out(3, -1.0);
+    const std::vector<int> indices{ 0, 1, 2 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    obtainCircularVector_into(out, indices, contents);
+    EXPECT_DOUBLE_EQ(out[0], 0.0);
+    EXPECT_DOUBLE_EQ(out[1], 0.0);
+    EXPECT_DOUBLE_EQ(out[2], 0.0);
+}
+
+TEST(ObtainCircularVectorInto, TooLargeIndexDoesNotReadOutOfBounds)
+{
+    std::vector<double> out(3, -1.0);
+    const std::vector<int> indices{ 1, 2, 10 };
+    const std::vector<double> contents{ 10.0, 20.0, 30.0 };
+    obtainCircularVector_into(out, indices, contents);
+    EXPECT_DOUBLE_EQ(out[0], 0.0);
+    EXPECT_DOUBLE_EQ(out[1], 0.0);
+    EXPECT_DOUBLE_EQ(out[2], 0.0);
+}

--- a/dynamic-neural-field-composer/tests/visualization/test_heatmap_dimensions.cpp
+++ b/dynamic-neural-field-composer/tests/visualization/test_heatmap_dimensions.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+
+#include "visualization/heatmap.h"
+
+using namespace dnf_composer;
+
+// ---------------------------------------------------------------------------
+// resolveManualHeatmapDimensions - issue #121
+//
+// Heatmap::render() (an ImGui/ImPlot render function, not headlessly
+// unit-testable per .claude/tests/05-gui-headless.md) computes manual-mode
+// rows/cols from user-editable axis extents/steps with no relationship to the
+// actual flattened-data buffer size, then hands rows*cols straight to
+// ImPlot::PlotHeatmap - a mismatched manual setting reads past the buffer.
+// This free function is the extracted, pure, testable core of that
+// computation (see heatmap.h for the extraction rationale).
+// ---------------------------------------------------------------------------
+
+TEST(ResolveManualHeatmapDimensions, MatchingSettingsAreUnclamped)
+{
+    // 10x10 grid, step 1 => rows=10, cols=10 = 100 elements, matches dataSize.
+    const auto dims = resolveManualHeatmapDimensions(10, 10, 1.0F, 1.0F, 100);
+    EXPECT_EQ(dims.rows, 10);
+    EXPECT_EQ(dims.cols, 10);
+    EXPECT_FALSE(dims.clamped);
+}
+
+TEST(ResolveManualHeatmapDimensions, MismatchedSettingsAreClampedToDataSize)
+{
+    // x_max/y_max imply a 100x100 grid (10000 elements) but only 100 elements
+    // are actually available (e.g. a small connected element with stale/
+    // user-edited axis maxes) - #121's out-of-bounds read.
+    const auto dims = resolveManualHeatmapDimensions(100, 100, 1.0F, 1.0F, 100);
+    EXPECT_LE(static_cast<std::size_t>(dims.rows) * static_cast<std::size_t>(dims.cols), 100u);
+    // rows is preserved (so the configured aspect ratio survives); cols is
+    // the one clamped down.
+    EXPECT_EQ(dims.rows, 100);
+    EXPECT_EQ(dims.cols, 1); // 100 / 100 = 1
+    EXPECT_TRUE(dims.clamped);
+}
+
+TEST(ResolveManualHeatmapDimensions, ZeroDataSizeYieldsEmptyGrid)
+{
+    const auto dims = resolveManualHeatmapDimensions(10, 10, 1.0F, 1.0F, 0);
+    EXPECT_EQ(dims.rows, 0);
+    EXPECT_EQ(dims.cols, 0);
+    EXPECT_FALSE(dims.clamped);
+}
+
+TEST(ResolveManualHeatmapDimensions, NonPositiveStepYieldsZeroForThatAxis)
+{
+    const auto dims = resolveManualHeatmapDimensions(10, 10, 0.0F, 1.0F, 100);
+    EXPECT_EQ(dims.cols, 0); // x_step <= 0 => degenerate, not out of bounds
+    EXPECT_EQ(dims.rows, 10);
+    EXPECT_FALSE(dims.clamped);
+}
+
+TEST(ResolveManualHeatmapDimensions, ClampNeverExceedsDataSizeForLargeExtents)
+{
+    // Pathological extents: rows*cols would overflow if computed naively.
+    const auto dims = resolveManualHeatmapDimensions(1'000'000, 1'000'000, 1.0F, 1.0F, 50);
+    EXPECT_TRUE(dims.clamped);
+    EXPECT_LE(static_cast<std::size_t>(dims.rows) * static_cast<std::size_t>(dims.cols), 50u);
+}

--- a/dynamic-neural-field-composer/wiki/Visualization.md
+++ b/dynamic-neural-field-composer/wiki/Visualization.md
@@ -65,6 +65,14 @@ visualization->plot(
 );
 ```
 
+`HeatmapParameters::autoDimensions` is on by default and derives the grid from the
+plotted element. Turning it off makes the grid come from the axis extents and steps
+in `PlotDimensions` instead — those are user-editable and have no built-in
+relationship to the data, so a combination implying more cells than the element holds
+would read past the buffer. Columns are now clamped so `rows * cols` never exceeds
+the available data (rows, and therefore the configured aspect ratio, are preserved),
+and a warning is logged when the clamp kicks in.
+
 ### Shorthand overloads
 
 ```cpp


### PR DESCRIPTION
Closes #121. Two unguarded out-of-bounds reads.

**Heatmap manual dimensions.** With `autoDimensions` off, `render()` derived `rows = y_max / y_step`, `cols = x_max / x_step` from user-editable axis fields and passed `rows * cols` straight to `ImPlot::PlotHeatmap`, with nothing tying those fields to the actual buffer size. The computation is extracted into a pure `resolveManualHeatmapDimensions()` that clamps columns so `rows * cols` fits the data — rows, and so the configured aspect ratio, are preserved. It compares by division rather than `rows * cols` to avoid overflow on pathological extents. The function is silent by design (it runs every frame); `render()` owns the logging and warns only when the clamp changes, not once per frame.

**`obtainCircularVector` / `_into`.** Both did `contents[indices[i] - 1]` on 1-based indices with no check, so an index of `0` read `contents[-1]`. Both are on the convolution hot path, so the whole index set is validated **once per call** rather than branching per element inside the copy loop — the loop stays vectorizable after #107. On violation they log an error and return zeros.

Tests: 5 cases for the dimension resolver (match, clamp, zero data, degenerate step, overflow-scale extents) and 6 for the gather (in-range, zero index, too-large index × both overloads). Suite 1107/1109 locally — the 2 failures are the known pre-existing `LoggerTest` order dependence fixed on #140.

Docs: `wiki/Visualization.md` documents the manual-dimension clamp; Doxygen on both functions; CHANGELOG updated.