### PR TITLE
fix: sever element connections on simulation teardown so elements are freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Connected elements were never destroyed. `addInput()` records a connection on both
+  endpoints — the consumer keeps its source in `inputs`, the source keeps the consumer
+  in `outputs` — so any two connected elements held `shared_ptr`s to each other. Neither
+  `Simulation::clean()` (which only cleared its own vector) nor destroying the
+  `Simulation` broke that cycle, so every connected element in every simulation leaked;
+  the canonical field↔self-kernel architecture leaked doubly. `clean()` and
+  `~Simulation()` now sever all connections before releasing the elements (#112)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/include/simulation/simulation.h
+++ b/dynamic-neural-field-composer/include/simulation/simulation.h
@@ -82,6 +82,11 @@ namespace dnf_composer
 		void resume();
 
 		/// @brief Remove all elements and reset the simulation to its initial state.
+		///
+		/// Connections are severed first: `addInput()` stores a `shared_ptr` on both
+		/// sides (the consumer keeps its source in `inputs`, the source keeps the
+		/// consumer in `outputs`), so simply dropping this simulation's references
+		/// would leave every connected element owning its peer and never freed (#112).
 		void clean();
 
 		/// @brief Serialize the simulation and its elements to a JSON file.
@@ -166,7 +171,10 @@ namespace dnf_composer
 		/// @brief Return true if the simulation is currently paused.
 		bool isPaused() const;
 
-		~Simulation() = default;
+		/// @brief Severs every element connection before releasing the elements, so
+		/// that connected elements are actually destroyed rather than kept alive by
+		/// each other. @see clean()
+		~Simulation();
 		std::chrono::nanoseconds lastStepDuration{ 0 };
 		std::chrono::nanoseconds accumulatedRunDuration{ 0 };
 		std::chrono::steady_clock::time_point runSegmentStart;
@@ -185,5 +193,10 @@ namespace dnf_composer
 		bool measureStepDuration = true;
 		SimulationRecorder recorder;
 		void generateUniqueIdentifier();
+
+		/// @brief Break every input/output connection between this simulation's
+		/// elements, so no element is left owning a peer. Safe to call more than
+		/// once and on an empty simulation.
+		void disconnectAllElements();
 	};
 }

--- a/dynamic-neural-field-composer/src/simulation/simulation.cpp
+++ b/dynamic-neural-field-composer/src/simulation/simulation.cpp
@@ -209,9 +209,26 @@ namespace dnf_composer
 		log(tools::logger::LogLevel::INFO, "Simulation resumed.");
 	}
 
+	void Simulation::disconnectAllElements()
+	{
+		for (const auto& element : elements)
+		{
+			// Each of these erases the connection from both endpoints, so after
+			// the loop no element holds a shared_ptr to any other.
+			element->removeInputs();
+			element->removeOutputs();
+		}
+	}
+
+	Simulation::~Simulation()
+	{
+		disconnectAllElements();
+	}
+
 	void Simulation::clean()
 	{
 		recorder.stopAll();
+		disconnectAllElements();
 		elements.clear();
 		initialized = false;
 		paused = false;

--- a/dynamic-neural-field-composer/tests/simulation/test_simulation.cpp
+++ b/dynamic-neural-field-composer/tests/simulation/test_simulation.cpp
@@ -397,3 +397,91 @@ TEST(SimulationChangeDimensions, UnconnectedElementResizesWithoutError)
     EXPECT_NO_THROW(sim.changeDimensions("field", ElementDimensions{ 75, 1.0 }));
     EXPECT_EQ(sim.getElement("field")->getSize(), 75);
 }
+
+// ---------------------------------------------------------------------------
+// Element lifetime - issue #112
+//
+// addInput() stores a shared_ptr on BOTH sides: the consumer keeps its source in
+// `inputs`, and the source keeps the consumer in `outputs`. That is a reference
+// cycle for *every* connection, so dropping the simulation's own references (via
+// clean(), or by destroying the Simulation) left every connected element alive
+// forever. The canonical DNF architecture - a field and its self-kernel wired
+// both ways - is the worst case: two cycles at once.
+//
+// These tests observe the elements through weak_ptr, which is the only way to
+// see a leak: expired() is false exactly when something still owns the element.
+// ---------------------------------------------------------------------------
+
+TEST(ElementLifetime, CleanReleasesConnectedElements)
+{
+    std::weak_ptr<Element> stimObserver;
+    std::weak_ptr<Element> fieldObserver;
+    {
+        Simulation sim("lifetime-clean", 1.0, 0.0, 0.0);
+        const auto stim = makeStimulus("stim");
+        const auto field = makeField("field");
+        sim.addElement(stim);
+        sim.addElement(field);
+        sim.createInteraction("stim", "output", "field");
+        sim.init();
+
+        stimObserver = stim;
+        fieldObserver = field;
+
+        sim.clean();
+        // The local shared_ptrs above still hold them; the point is what happens
+        // once those go out of scope with the simulation's references dropped.
+    }
+
+    EXPECT_TRUE(stimObserver.expired()) << "connected input element outlived every owner";
+    EXPECT_TRUE(fieldObserver.expired()) << "connected output element outlived every owner";
+}
+
+TEST(ElementLifetime, DestroyingSimulationReleasesConnectedElements)
+{
+    std::weak_ptr<Element> stimObserver;
+    std::weak_ptr<Element> fieldObserver;
+    {
+        const auto sim = std::make_shared<Simulation>("lifetime-dtor", 1.0, 0.0, 0.0);
+        const auto stim = makeStimulus("stim");
+        const auto field = makeField("field");
+        sim->addElement(stim);
+        sim->addElement(field);
+        sim->createInteraction("stim", "output", "field");
+        sim->init();
+
+        stimObserver = stim;
+        fieldObserver = field;
+    }
+
+    EXPECT_TRUE(stimObserver.expired());
+    EXPECT_TRUE(fieldObserver.expired());
+}
+
+TEST(ElementLifetime, RecurrentFieldAndKernelAreReleased)
+{
+    // field -> kernel -> field: the standard DNF self-excitation loop, and a
+    // cycle through `inputs` on both sides as well as through `outputs`.
+    std::weak_ptr<Element> fieldObserver;
+    std::weak_ptr<Element> kernelObserver;
+    {
+        Simulation sim("lifetime-recurrent", 1.0, 0.0, 0.0);
+        const auto field = makeField("field");
+        const ElementCommonParameters kcp{ "kernel", 100 };
+        const GaussKernelParameters kp{ 5.0, 10.0, 0.0 };
+        const auto kernel = std::make_shared<GaussKernel>(kcp, kp);
+        sim.addElement(field);
+        sim.addElement(kernel);
+        sim.createInteraction("field", "output", "kernel");
+        sim.createInteraction("kernel", "output", "field");
+        sim.init();
+
+        fieldObserver = field;
+        kernelObserver = kernel;
+
+        sim.clean();
+    }
+
+    EXPECT_TRUE(fieldObserver.expired()) << "recurrent field outlived every owner";
+    EXPECT_TRUE(kernelObserver.expired()) << "recurrent kernel outlived every owner";
+}

--- a/dynamic-neural-field-composer/wiki/Simulation.md
+++ b/dynamic-neural-field-composer/wiki/Simulation.md
@@ -42,6 +42,14 @@ sim.clean();         // removes all elements without closing
 
 `init()` must be called before the first `step()`. When using `Application`, `app.init()` handles this automatically.
 
+`clean()` and the destructor both sever every connection between the simulation's
+elements before releasing them. This matters because `addInput()` records the
+connection on both endpoints — the consumer holds its source, and the source holds
+the consumer — so two connected elements own each other. Dropping only the
+simulation's own references would leave that pair alive indefinitely. If you hold
+elements outside a simulation and wire them together directly, call `removeInputs()`
+/ `removeOutputs()` yourself before letting them go.
+
 ---
 
 ## Element management


### PR DESCRIPTION
Closes #112.

`addInput()` records a connection on **both** endpoints — the consumer keeps its source in `inputs`, and the source keeps the consumer in `outputs`. Those are both owning `shared_ptr`s, so *any* two connected elements own each other. `Simulation::clean()` only did `elements.clear()` and the destructor was `= default`, so neither broke the cycle: every connected element in every simulation was leaked. The canonical DNF field↔self-kernel pair leaks twice over, and `clean()` runs on every File→Open and File→Quit.

The scope is wider than the issue describes — it is not limited to recurrent wiring; a plain stimulus→field connection leaks both elements.

`clean()` and `~Simulation()` now sever all connections before releasing the elements. No type or signature changes: `inputs` stays owning (the input cache holds raw pointers into each source's buffer, so a source must outlive its consumer), and the fix is placed where ownership actually lives — the Simulation, which is the sole owner of elements.

Tests: three `ElementLifetime` cases observing elements through `weak_ptr` — clean(), destructor, and the recurrent field/kernel pair. All three fail on `main` and pass here. Suite 1099/1101 locally — the 2 failures are the known pre-existing `LoggerTest` order dependence fixed on #140.

Docs: `wiki/Simulation.md` explains the two-sided connection and what to do when wiring elements outside a simulation; Doxygen on `clean()`, the destructor, and the new private helper; CHANGELOG updated.