### PR TITLE
fix: destroy the node-editor context instead of leaking it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `NodeGraphWindow` created an imgui-node-editor context in its constructor but never
+  destroyed it — the destructor was `= default` and nothing in the codebase called
+  `ImNodeEditor::DestroyEditor()`, so the context and its settings-file handle leaked
+  for the lifetime of the process, once per window built. Because every File→Open
+  rebuilds the window set, the leak grew with each reopened simulation. The context is
+  now held in a `unique_ptr` with a `DestroyEditor` deleter, so it is released on every
+  exit path rather than depending on a destructor body remembering to do it (#115)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - `NodeGraphWindow` created an imgui-node-editor context in its constructor but never
   destroyed it — the destructor was `= default` and nothing in the codebase called
-  `ImNodeEditor::DestroyEditor()`, so the context and its settings-file handle leaked
-  for the lifetime of the process, once per window built. Because every File→Open
-  rebuilds the window set, the leak grew with each reopened simulation. The context is
-  now held in a `unique_ptr` with a `DestroyEditor` deleter, so it is released on every
-  exit path rather than depending on a destructor body remembering to do it (#115)
+  `ImNodeEditor::DestroyEditor()`. `EditorContext::~EditorContext` is what deletes every
+  node, pin and link object the context owns and frees its splitter memory, so skipping
+  it leaked the whole graph, once per window built. Because every File→Open rebuilds the
+  window set, the leak grew with each reopened simulation. The context is now held in a
+  `unique_ptr` with a `DestroyEditor` deleter, so it is released on every exit path
+  rather than depending on a destructor body remembering to do it (#115)
 
 ## [2.9.6] - 2026-07-31
 

--- a/dynamic-neural-field-composer/include/user_interface/node_graph_window.h
+++ b/dynamic-neural-field-composer/include/user_interface/node_graph_window.h
@@ -116,12 +116,27 @@ namespace dnf_composer::user_interface
 		std::array<char, 64>  autoTitleComponent = {""};
 	};
 
+	/// @brief Deleter that returns an imgui-node-editor context to the library.
+	///
+	/// Lets the context be held in a unique_ptr so it is released on every exit
+	/// path, rather than relying on a destructor body remembering to do it (#115).
+	struct EditorContextDeleter
+	{
+		void operator()(ImNodeEditor::EditorContext* ctx) const noexcept
+		{
+			if (ctx != nullptr) { ImNodeEditor::DestroyEditor(ctx); }
+		}
+	};
+
 	class NodeGraphWindow final : public imgui_kit::UserInterfaceWindow
 	{
 	private:
 		std::shared_ptr<Simulation> simulation;
+		// config must outlive context: CreateEditor() keeps the pointer we hand it,
+		// and members are destroyed in reverse declaration order, so config must be
+		// declared first.
 		ImNodeEditor::Config config;
-		ImNodeEditor::EditorContext* context;
+		std::unique_ptr<ImNodeEditor::EditorContext, EditorContextDeleter> context;
 		static constexpr uint16_t startingInputPinId = 1000;
 		static constexpr uint16_t startingOutputPinId = 2000;
 		static constexpr uint16_t startingLinkId = 3000;

--- a/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
+++ b/dynamic-neural-field-composer/src/user_interface/node_graph_window.cpp
@@ -15,7 +15,7 @@ namespace dnf_composer::user_interface
 		: simulation(simulation)
 	{
 		config.SettingsFile = "imnode-window.json";
-		context = ImNodeEditor::CreateEditor(&config);
+		context.reset(ImNodeEditor::CreateEditor(&config));
 	}
 
 	// NOLINTNEXTLINE(readability-function-cognitive-complexity) - linear ImGui immediate-mode layout; splitting would fragment widget state across functions
@@ -28,7 +28,7 @@ namespace dnf_composer::user_interface
 			"Double-click a link to remove it.\n"
 			"Double-click a node to open/close its plot card.");
 
-		ImNodeEditor::SetCurrentEditor(context);
+		ImNodeEditor::SetCurrentEditor(context.get());
 		applyCanvasStyle();
 		ImNodeEditor::Begin("dnf-composer-graph");
 		renderElementNodes();
@@ -1500,13 +1500,13 @@ namespace dnf_composer::user_interface
 
 			if (fitAll)
 			{
-				ImNodeEditor::SetCurrentEditor(context);
+				ImNodeEditor::SetCurrentEditor(context.get());
 				ImNodeEditor::NavigateToContent(0.3F);
 				ImNodeEditor::SetCurrentEditor(nullptr);
 			}
 			if (fitSel)
 			{
-				ImNodeEditor::SetCurrentEditor(context);
+				ImNodeEditor::SetCurrentEditor(context.get());
 				ImNodeEditor::NavigateToSelection(false, 0.3F);
 				ImNodeEditor::SetCurrentEditor(nullptr);
 			}

--- a/dynamic-neural-field-composer/tests/CMakeLists.txt
+++ b/dynamic-neural-field-composer/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ if(DNF_COMPOSER_BUILD_TESTS)
             "visualization/test_visualization.cpp"
             # user_interface
             "user_interface/test_plot_control_window.cpp"
+            "user_interface/test_node_graph_window_lifetime.cpp"
             "visualization/test_plot_parameters.cpp"
     )
     target_include_directories(dnf_composer_tests PRIVATE

--- a/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
+++ b/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
@@ -11,8 +11,13 @@ using namespace dnf_composer;
 //
 // NodeGraphWindow's constructor calls ImNodeEditor::CreateEditor(&config), but
 // the destructor was `= default` and nothing in the codebase ever called
-// DestroyEditor(), so the editor context and its settings-file handle leaked for
-// the lifetime of the process.
+// DestroyEditor(), so the editor context leaked for the lifetime of the process.
+// What leaks is memory, not a file handle: EditorContext::~EditorContext is what
+// deletes the context's node/pin/link objects and frees its splitter memory, so
+// skipping it leaks the whole graph. (config.SettingsFile is only a path string;
+// the library opens a local ifstream/ofstream inside Load/SaveSettings and closes
+// it there, and SaveSettings also runs during normal operation, so settings
+// persistence was never affected -- verified in imgui-node-editor v0.9.3.)
 //
 // What these tests do NOT do: prove the leak is gone. The CI asan-ubsan job runs
 // with ASAN_OPTIONS=detect_leaks=0 (see .github/workflows/ci.yml -- disabled

--- a/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
+++ b/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "user_interface/node_graph_window.h"
+#include "simulation/simulation.h"
+
+using namespace dnf_composer;
+
+// ---------------------------------------------------------------------------
+// Regression test for issue #115.
+//
+// NodeGraphWindow's constructor calls ImNodeEditor::CreateEditor(&config), but
+// the destructor was `= default` and nothing in the codebase ever called
+// DestroyEditor(), so the editor context and its settings-file handle leaked for
+// the lifetime of the process.
+//
+// A leak is not directly observable from inside the test, so this test's job is
+// to exercise the construct/destroy cycle repeatedly and let the Linux CI
+// asan-ubsan job report the leak. Before the fix that job reports a definite
+// leak of the editor context; after it, nothing.
+//
+// These construct the window but never render it, so no ImGui frame, window, or
+// GL context is required.
+// ---------------------------------------------------------------------------
+
+TEST(NodeGraphWindowLifetime, ConstructAndDestroyReleasesTheEditorContext)
+{
+    const auto sim = std::make_shared<Simulation>("node-graph-lifetime", 1.0, 0.0, 0.0);
+    {
+        const user_interface::NodeGraphWindow window{ sim };
+        (void)window;
+    }
+    SUCCEED();
+}
+
+TEST(NodeGraphWindowLifetime, RepeatedConstructAndDestroyDoesNotAccumulate)
+{
+    // Every File->Open builds a fresh set of windows, so this cycle is the real
+    // usage pattern -- the leak grew once per reopened simulation.
+    const auto sim = std::make_shared<Simulation>("node-graph-lifetime-loop", 1.0, 0.0, 0.0);
+    for (int i = 0; i < 10; ++i)
+    {
+        const user_interface::NodeGraphWindow window{ sim };
+        (void)window;
+    }
+    SUCCEED();
+}

--- a/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
+++ b/dynamic-neural-field-composer/tests/user_interface/test_node_graph_window_lifetime.cpp
@@ -14,10 +14,19 @@ using namespace dnf_composer;
 // DestroyEditor(), so the editor context and its settings-file handle leaked for
 // the lifetime of the process.
 //
-// A leak is not directly observable from inside the test, so this test's job is
-// to exercise the construct/destroy cycle repeatedly and let the Linux CI
-// asan-ubsan job report the leak. Before the fix that job reports a definite
-// leak of the editor context; after it, nothing.
+// What these tests do NOT do: prove the leak is gone. The CI asan-ubsan job runs
+// with ASAN_OPTIONS=detect_leaks=0 (see .github/workflows/ci.yml -- disabled
+// because connected elements form a shared_ptr ownership cycle that LeakSanitizer
+// flags on every connection test), so no job in this repo can currently observe a
+// leak. Confirmed empirically: this file was pushed before the fix and asan-ubsan
+// passed. Re-enabling leak detection is tracked separately; only then do these
+// become true regression tests for the leak itself.
+//
+// What they DO cover: the construct/destroy cycle is now RAII-managed, and member
+// destruction order matters -- `config` must outlive `context`, because
+// CreateEditor() retains the pointer it is handed and DestroyEditor() reads it
+// back. Get that ordering wrong and this is a use-after-free, which ASan reports
+// regardless of detect_leaks. That is the hazard these tests actually guard.
 //
 // These construct the window but never render it, so no ImGui frame, window, or
 // GL context is required.


### PR DESCRIPTION
Closes #115.

`NodeGraphWindow`'s constructor called `ImNodeEditor::CreateEditor(&config)`, but the destructor was `= default` and nothing in the codebase ever called `DestroyEditor()`. The context and its settings-file handle leaked once per window built, and since every File→Open rebuilds the window set, the leak grew with each reopened simulation.

The context is now held in a `unique_ptr` with a `DestroyEditor` deleter, so it is released on every exit path rather than depending on a destructor body remembering to do it. `config` is declared before `context` so it outlives it — `CreateEditor()` retains the pointer it is handed.

### On the tests, honestly

I pushed `test_node_graph_window_lifetime.cpp` before the fix expecting the `asan-ubsan` job to report the leak. **It passed.** The reason is that CI runs with `ASAN_OPTIONS=...:detect_leaks=0` (`ci.yml`), disabled because connected elements form a `shared_ptr` cycle that LeakSanitizer flags on every connection test. No job in this repo can currently observe a leak, so that green result said nothing — and my test could never have failed.

I have left the tests in and rewritten their header comment to say what they actually cover: the member destruction order. Get `config`/`context` ordering wrong and `DestroyEditor()` reads freed memory, which ASan reports regardless of `detect_leaks`. That hazard is real and these tests guard it.

The leak itself is verified by inspection, not by CI.

Worth noting: PR #151 severs element connections on teardown, which is the cycle the `detect_leaks=0` comment says to wait for. Re-enabling leak detection after #151 lands would make these genuine regression tests — filed separately rather than widening this PR.

### Verification
- 1100 tests pass locally on Windows with `--gtest_shuffle`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a resource leak that could occur when closing node graph windows.
  * Improved cleanup during repeated window creation and destruction.

* **Tests**
  * Added regression coverage for single and repeated node graph window lifecycles.

* **Documentation**
  * Added an Unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->