### PR TITLE
fix: soft-fail doc-sync on Gemini quota exhaustion

### DIFF
--- a/.github/workflows/gemini-doc-sync.yml
+++ b/.github/workflows/gemini-doc-sync.yml
@@ -21,7 +21,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The free tier allows 20 requests a day. Once it is spent, every subsequent
+      # PR shows a red doc-sync that says nothing about the PR. The failure is
+      # swallowed here and re-raised by the next step unless it was the quota, so
+      # a genuine failure still fails the job.
       - name: Check documentation completeness with Gemini
+        id: doc_sync
+        continue-on-error: true
         uses: google-github-actions/run-gemini-cli@055c24c9f565debe282e4adf1f7ca1715040ebe2 # v0 (2026-06-19)
         with:
           gemini_cli_version: latest
@@ -87,3 +93,18 @@ jobs:
         env:
           GEMINI_CLI_TRUST_WORKSPACE: 'true'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Fails closed: only an error positively identified as quota exhaustion is
+      # tolerated. An unrecognised or empty error still fails the job.
+      - name: Tolerate quota exhaustion, fail on anything else
+        if: steps.doc_sync.outcome == 'failure'
+        env:
+          DOC_SYNC_ERROR: ${{ steps.doc_sync.outputs.error }}
+        run: |
+          if printf '%s' "$DOC_SYNC_ERROR" | grep -qiE 'exhausted your daily quota|RESOURCE_EXHAUSTED|rate limit|\b429\b|quota exceeded'; then
+            echo "::warning title=doc-sync skipped::Gemini quota exhausted; documentation sync check did not run."
+            exit 0
+          fi
+          echo "::error title=doc-sync failed::Gemini CLI failed for a reason other than quota exhaustion."
+          printf '%s\n' "$DOC_SYNC_ERROR"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The `doc-sync` check went red on every open PR once the Gemini free tier's 20
+  requests a day were spent, reporting a quota error that said nothing about the PR
+  under review. Quota exhaustion is now tolerated with a warning. The gate fails
+  closed: an error that is not positively identified as a quota or rate limit — and
+  an empty one — still fails the job (#148)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed


### PR DESCRIPTION
The Gemini free tier allows 20 requests a day. Once spent, `doc-sync` went red on every open PR with an error about the quota rather than about the PR — 11 of 14 were red on this alone, which trains everyone to ignore the check.

Quota exhaustion is now tolerated with a warning. The gate fails closed: the Gemini step is wrapped in `continue-on-error`, and a following step re-raises the failure unless the captured error matches a known quota or rate-limit signature. An unrecognised error — or an empty one — still fails the job, so a real failure is not swallowed.

Verified the action writes `gemini_errors` to `GITHUB_OUTPUT` before its `exit 1`, so the error text is available to the gate.

The matcher was tested against the recorded payload from the failure this fixes (run 30678854179, `"You have exhausted your daily quota on this model."`) plus `RESOURCE_EXHAUSTED`, HTTP 429, and rate-limit prose, and against cases that must still fail: auth failure, network failure, a generic crash, empty output, and `4290` (which must not match `429`). 10/10 against the script as it appears in the workflow.

Closes #148
