### PR TITLE
fix: never close an issue as a duplicate of itself

### DIFF
--- a/.github/workflows/gemini-issue-triage.yml
+++ b/.github/workflows/gemini-issue-triage.yml
@@ -34,8 +34,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
+          # The issue being triaged is already in the list, and Gemini has marked a
+          # new issue as a duplicate of itself. Drop it before asking.
           gh issue list --state all --limit 100 --json number,title,state \
+            --jq "map(select(.number != ${ISSUE_NUMBER}))" \
             > /tmp/existing_issues.json
           {
             echo "fetched<<EOF"
@@ -111,7 +115,6 @@ jobs:
         run: |
           TYPE_LABEL=$(echo "$TRIAGE"    | jq -r '.type_label')
           PRIORITY=$(echo "$TRIAGE"      | jq -r '.priority_label')
-          SECONDARY=$(echo "$TRIAGE"     | jq -r '.secondary_labels[]' 2>/dev/null || true)
           DUPLICATE_OF=$(echo "$TRIAGE"  | jq -r '.duplicate_of // empty')
           COMMENT=$(echo "$TRIAGE"       | jq -r '.comment')
 
@@ -129,21 +132,34 @@ jobs:
             PRIORITY="priority: medium"
           fi
 
-          # Build comma-separated label list, validating secondary labels
-          ALLOWED_SECONDARY="help wanted good first issue duplicate"
-          LABELS="$TYPE_LABEL,$PRIORITY"
-          for lbl in $SECONDARY; do
-            if echo "$ALLOWED_SECONDARY" | grep -qw "$lbl"; then
-              LABELS="$LABELS,$lbl"
-            else
-              echo "Skipping unexpected secondary label: '$lbl'"
-            fi
-          done
+          # One --add-label per label. Two of the allowed secondary labels contain
+          # spaces, so an unquoted loop over a word-split list turned "good first
+          # issue" into the three labels good, first and issue, none of which exist,
+          # and the whole step failed before it could comment.
+          LABEL_ARGS=(--add-label "$TYPE_LABEL" --add-label "$PRIORITY")
+          while IFS= read -r lbl; do
+            [ -n "$lbl" ] || continue
+            case "$lbl" in
+              "help wanted"|"good first issue"|"duplicate")
+                LABEL_ARGS+=(--add-label "$lbl") ;;
+              *)
+                echo "Skipping unexpected secondary label: '$lbl'" ;;
+            esac
+          done < <(echo "$TRIAGE" | jq -r '.secondary_labels[]' 2>/dev/null || true)
 
-          gh issue edit "$ISSUE_NUMBER" --add-label "$LABELS"
+          gh issue edit "$ISSUE_NUMBER" "${LABEL_ARGS[@]}"
           gh issue comment "$ISSUE_NUMBER" --body "$COMMENT"
 
+          # Close only against a real, different issue. Gemini has returned this
+          # issue's own number, which closed a freshly filed issue as a duplicate of
+          # itself, and a non-numeric answer would produce a nonsense close comment.
           if [ -n "$DUPLICATE_OF" ]; then
-            gh issue close "$ISSUE_NUMBER" --reason "not planned" \
-              --comment "Closing as duplicate of #${DUPLICATE_OF}."
+            if ! echo "$DUPLICATE_OF" | grep -qE '^[0-9]+$'; then
+              echo "Ignoring non-numeric duplicate_of '$DUPLICATE_OF'"
+            elif [ "$DUPLICATE_OF" = "$ISSUE_NUMBER" ]; then
+              echo "Ignoring self-referential duplicate_of #${DUPLICATE_OF}"
+            else
+              gh issue close "$ISSUE_NUMBER" --reason "not planned" \
+                --comment "Closing as duplicate of #${DUPLICATE_OF}."
+            fi
           fi

--- a/.github/workflows/gemini-issue-triage.yml
+++ b/.github/workflows/gemini-issue-triage.yml
@@ -37,9 +37,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           # The issue being triaged is already in the list, and Gemini has marked a
-          # new issue as a duplicate of itself. Drop it before asking.
-          gh issue list --state all --limit 100 --json number,title,state \
-            --jq "map(select(.number != ${ISSUE_NUMBER}))" \
+          # new issue as a duplicate of itself. Drop it before asking. Fetch 101 so
+          # that removing this issue still leaves a full 100 candidates, then trim
+          # back to 100 for the case where it was not in the window at all.
+          gh issue list --state all --limit 101 --json number,title,state \
+            --jq "map(select(.number != ${ISSUE_NUMBER}))[0:100]" \
             > /tmp/existing_issues.json
           {
             echo "fetched<<EOF"
@@ -156,10 +158,18 @@ jobs:
           if [ -n "$DUPLICATE_OF" ]; then
             if ! echo "$DUPLICATE_OF" | grep -qE '^[0-9]+$'; then
               echo "Ignoring non-numeric duplicate_of '$DUPLICATE_OF'"
-            elif [ "$DUPLICATE_OF" = "$ISSUE_NUMBER" ]; then
-              echo "Ignoring self-referential duplicate_of #${DUPLICATE_OF}"
             else
-              gh issue close "$ISSUE_NUMBER" --reason "not planned" \
-                --comment "Closing as duplicate of #${DUPLICATE_OF}."
+              # Normalise before comparing and before quoting the number back. "00158"
+              # passes the digit check but is not string-equal to "158", so a padded
+              # answer would slip past the self-reference guard and close the issue
+              # against itself anyway. 10# forces base 10, or 08/09 would be read as
+              # invalid octal.
+              DUP_NUM=$((10#$DUPLICATE_OF))
+              if [ "$DUP_NUM" -eq "$ISSUE_NUMBER" ]; then
+                echo "Ignoring self-referential duplicate_of #${DUP_NUM}"
+              else
+                gh issue close "$ISSUE_NUMBER" --reason "not planned" \
+                  --comment "Closing as duplicate of #${DUP_NUM}."
+              fi
             fi
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The issue-triage workflow closed newly filed issues as duplicates of themselves —
+  the issue list handed to Gemini for duplicate detection was fetched after the issue
+  was opened, so it contained the issue being triaged, and nothing rejected a
+  self-referential `duplicate_of` before closing. The triaged issue is now filtered out
+  of that list, and a close only happens when `duplicate_of` is numeric and refers to a
+  different issue. Secondary labels are also no longer word-split, so `good first issue`
+  and `help wanted` are applied as single labels instead of failing the step (#159)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed


### PR DESCRIPTION
The triage workflow closed issue #158 as a duplicate of itself, one second after it was filed. Any new issue could disappear from the backlog this way.

Three defects, all in `gemini-issue-triage.yml`:

- The duplicate-candidate list is fetched after the issue is opened, so the issue being triaged is offered to the model as a duplicate of itself, and nothing rejected that before closing. The issue is now filtered out of the list, and a close requires `duplicate_of` to differ from the triaged issue.
- `duplicate_of` was interpolated into the close comment unvalidated — a non-numeric answer produced `Closing as duplicate of #the vcpkg one.` and still closed. It must now be numeric.
- `for lbl in $SECONDARY` word-split multi-word labels, so `good first issue` became `good`, `first`, `issue`; `good`, `first`, `help` and `wanted` all matched `grep -qw` against the flat allow-list and were added as labels. None exist, so `gh issue edit` failed and the welcome comment was never posted. Labels are now built as an array with one `--add-label` each, read line by line and matched exactly.

Verified by extracting the step's `run:` body from the YAML and executing it with `gh` stubbed, so the text under test is the text that runs. 12 cases: 5 fail on `main` (the two self-duplicate paths, the non-numeric close, and both multi-word labels) and all 12 pass here. Genuine duplicates of a different issue still close as before.

Closes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated issue triage by excluding the current issue from duplicate detection.
  * Prevented issues from being incorrectly closed as duplicates of themselves.
  * Preserved multi-word labels when applying triage labels.
  * Ignored unsupported labels and invalid duplicate issue references.

* **Documentation**
  * Added unreleased changelog notes covering these issue triage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->