### PR TITLE
test: pin sigmoid apply() and operator() to the same result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `SigmoidFunction.ApplyAgreesWithOperatorCallAcrossRegimes`: pins `apply()` (the path
+  `NeuralField::calculateOutput()` takes every step) to `operator()` within 1e-12 across
+  five steepness/shift regimes. The two once disagreed — `apply()` computed in float32
+  while `operator()` used float64, so the same field gave different results depending on
+  which ran, a reproducibility hazard for threshold-driven stability detection. Both have
+  been float64 since "Sigmoid to float64 end-to-end"; this closes the acceptance criterion
+  that was never covered. The old split shows up as a ~2e-7 discrepancy here, five orders
+  of magnitude above the tolerance (#120)
+
+### Documentation
+- `tests/golden/test_golden_activation.cpp` still described `SigmoidFunction::apply()` as
+  computing in float32 and the reference as mirroring that; both have been float64 for
+  some time and `reference/ref_activation.h` already said so
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
+++ b/dynamic-neural-field-composer/tests/elements/test_activation_function.cpp
@@ -94,6 +94,43 @@ TEST(SigmoidFunction, ToStringIsNonEmpty)
     EXPECT_FALSE(s.toString().empty());
 }
 
+// apply() is the path NeuralField::calculateOutput() takes every step; operator()
+// is the path callers reach for. They once disagreed: apply() computed in float32
+// while operator() used float64, so the same field gave different results
+// depending on which one ran, and threshold-driven stability detection could flip.
+// Both are float64 now. This pins them together — the old split showed up here as
+// a ~2e-7 discrepancy, five orders of magnitude above this tolerance.
+TEST(SigmoidFunction, ApplyAgreesWithOperatorCallAcrossRegimes)
+{
+    struct Regime { double x_shift; double steepness; };
+    const std::vector<Regime> regimes{
+        { 0.0, 10.0 }, { 5.0, 4.0 }, { -3.0, 20.0 },
+        { 0.0, 100.0 },  // steep, near-Heaviside
+        { 0.0, 0.5 },    // very shallow
+    };
+
+    std::vector<double> input(401);
+    for (size_t i = 0; i < input.size(); ++i)
+        input[i] = -20.0 + 40.0 * static_cast<double>(i) / 400.0;
+
+    for (const auto& [x_shift, steepness] : regimes)
+    {
+        SigmoidFunction s{ x_shift, steepness };
+
+        const auto viaOperator = s(input);
+        std::vector<double> viaApply(input.size());
+        s.apply(input, viaApply);
+
+        ASSERT_EQ(viaApply.size(), viaOperator.size());
+        for (size_t i = 0; i < input.size(); ++i)
+        {
+            EXPECT_NEAR(viaApply[i], viaOperator[i], 1e-12)
+                << "x_shift=" << x_shift << " steepness=" << steepness
+                << " x=" << input[i];
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // HeavisideFunction
 // ---------------------------------------------------------------------------

--- a/dynamic-neural-field-composer/tests/golden/test_golden_activation.cpp
+++ b/dynamic-neural-field-composer/tests/golden/test_golden_activation.cpp
@@ -5,10 +5,12 @@
 //  by NeuralField::calculateOutput() every step) vs an independent reference
 //  re-derivation in reference/ref_activation.h.
 //
-//  NOTE on SigmoidFunction: apply() computes internally in float32, a precision
-//  inconsistency vs. its own operator() (float64) — see the ref_activation.h
-//  header comment. We mirror that float32 computation bit-for-bit so this stays
-//  a genuine 1e-9 analytic equivalence test, not a loosened tolerance.
+//  NOTE on SigmoidFunction: apply() computes in float64, matching its own
+//  operator() — the float32/float64 split between the two is gone. The reference
+//  mirrors the float64 computation, including the [-88, 88] exponent clamp, so
+//  this stays a genuine 1e-9 analytic equivalence test, not a loosened tolerance.
+//  The two production paths are pinned to each other by
+//  SigmoidFunction.ApplyAgreesWithOperatorCallAcrossRegimes.
 // ----------------------------------------------------------------------------
 #include <gtest/gtest.h>
 #include <string>


### PR DESCRIPTION
#120 reported that `SigmoidFunction::apply()` computed in float32 while `operator()` used float64, so the same field gave different results depending on which path ran.

The float32 code is already gone — `d326484a "Sigmoid to float64 end-to-end"` replaced it while doing perf work, without closing the issue. What was never done is the issue's second acceptance criterion: a test asserting the two paths agree.

This adds it. `SigmoidFunction.ApplyAgreesWithOperatorCallAcrossRegimes` compares `apply()` against `operator()` to 1e-12 over 401 samples in five regimes, including the near-Heaviside and very shallow ends.

The assertion has teeth: compiling the old float32 formula from the issue alongside the current one, the old path diverges from `operator()` by 2.1e-08 to 2.3e-07 depending on regime, while the current path agrees to 6.1e-39. The tolerance sits five orders of magnitude below the old error, so a regression to float32 fails this test in every regime.

Also corrects the banner comment in `tests/golden/test_golden_activation.cpp`, which still described `apply()` as float32 and the reference as mirroring that float32 computation bit-for-bit. `reference/ref_activation.h` was already updated; this file was missed.

Test-only, no production change. Full suite: 1099/1099 pass.

Closes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical consistency for sigmoid activation calculations across varied input ranges.
  * Updated activation behavior documentation to reflect double-precision computation and exponent handling.

* **Tests**
  * Added regression coverage confirming both sigmoid calculation paths agree within a strict tolerance across multiple parameter regimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->