### PR TITLE
docs: fix CONTRIBUTING build, test and wiki-link inaccuracies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+- `CONTRIBUTING.md` told contributors to run `build.bat` / `./build.sh` / `./build_macos.sh`
+  from the repository root, but those scripts live in `dynamic-neural-field-composer/scripts/`,
+  so every build command failed on a fresh clone. It also listed a GCC 11+ minimum while the
+  README and CI both require GCC 13+, gave a `ctest --build-config Release` invocation that
+  cannot work against the single-config build trees the scripts produce (and was run from a
+  directory with no test configuration), and linked to `wiki/Getting-Started.md` when the page
+  is `wiki/Getting Started.md`. All corrected, with the setup step and the per-platform CTest
+  directories documented (#132)
+
 ## [2.9.6] - 2026-07-31
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,26 +19,44 @@ Open an issue on GitHub using the appropriate template:
 
 | Requirement | Minimum |
 |---|---|
-| C++ compiler | C++20 (MSVC 2022, GCC 11+, Clang 13+, Apple Clang 13+) |
+| C++ compiler | C++20 (MSVC 2022, GCC 13+, Apple Clang via Xcode Command Line Tools) |
 | CMake | 3.20 |
 | vcpkg | Any recent — set `VCPKG_ROOT` |
 
-**Build**
+CI builds on Windows (MSVC 2022), Linux (GCC 13) and macOS. Other C++20 compilers may work but are not covered by CI.
+
+**Setup**
+
+The setup script installs the dependencies and sets `VCPKG_ROOT`. Run it once, from the repository root:
 
 ```bat
-# Windows
-build.bat
+:: Windows
+dynamic-neural-field-composer\scripts\setup.bat
+```
+
+```bash
+# Linux and macOS
+./dynamic-neural-field-composer/scripts/setup.sh
+```
+
+**Build**
+
+The build scripts live in `dynamic-neural-field-composer/scripts/`. They resolve their own paths, so you can invoke them from anywhere — the commands below assume the repository root:
+
+```bat
+:: Windows — configures and builds both x64-release and x64-debug
+dynamic-neural-field-composer\scripts\build.bat
 ```
 
 ```bash
 # Linux
-./build.sh
+./dynamic-neural-field-composer/scripts/build.sh
 
 # macOS
-./build_macos.sh
+./dynamic-neural-field-composer/scripts/build_macos.sh
 ```
 
-See [Getting Started](dynamic-neural-field-composer/wiki/Getting-Started.md) for full instructions and manual CMake options.
+See [Getting Started](dynamic-neural-field-composer/wiki/Getting%20Started.md) for full instructions and manual CMake options.
 
 ---
 
@@ -61,11 +79,22 @@ The existing codebase does not perfectly meet these standards everywhere — tes
 
 **Tests**
 
-Every change to element behaviour, simulation logic, or utilities must be covered by a test in `tests/`. The test executable is `dnf_composer_tests` (Google Test).
+Every change to element behaviour, simulation logic, or utilities must be covered by a test in `tests/`. The test executable is `dnf_composer_tests` (Google Test), registered with CTest via `gtest_discover_tests`.
+
+The build scripts produce a single-config build tree per platform, so point CTest at the one the script created:
 
 ```bash
-ctest --build-config Release --output-on-failure
+# Windows
+ctest --test-dir dynamic-neural-field-composer/build/x64-release --output-on-failure
+
+# Linux
+ctest --test-dir dynamic-neural-field-composer/build/linux-release --output-on-failure
+
+# macOS
+ctest --test-dir dynamic-neural-field-composer/build/macos-release --output-on-failure
 ```
+
+New test source files must be added to the explicit source list in `dynamic-neural-field-composer/tests/CMakeLists.txt` — the build does not glob, so an unlisted file is silently never compiled.
 
 **Doxygen**
 


### PR DESCRIPTION
Every build and test command in `CONTRIBUTING.md` failed on a fresh clone.

- Build scripts were given as `build.bat` / `./build.sh` / `./build_macos.sh` from the repository root, but they live in `dynamic-neural-field-composer/scripts/`. They resolve their own paths, so invoking them by path works from anywhere.
- Minimum compiler said GCC 11+; README and CI both require GCC 13+.
- `ctest --build-config Release` cannot work here: it was run from a directory with no test configuration, and `--build-config` applies to multi-config generators while the scripts produce single-config Ninja trees. Replaced with the per-platform `--test-dir` invocations (`--test-dir` needs CMake 3.20, which is already the stated minimum).
- The Getting Started link pointed at `wiki/Getting-Started.md`; the page is `wiki/Getting Started.md`.

Also documents the setup step, which the build scripts require but the file never mentioned, and notes that `tests/CMakeLists.txt` is an explicit source list rather than a glob.

Partially addresses #132 — the Doxygen half (undocumented `user_interface/`, `visualization/` and `tools/` headers) is untouched, because those headers are owned by other open PRs right now. Left open for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup instructions with current compiler requirements and supported CI platforms.
  * Clarified repository setup, path-independent build commands, and platform-specific build directories.
  * Expanded testing guidance, including CTest registration and required test source configuration.
  * Corrected the Getting Started documentation link.
  * Added an Unreleased changelog entry summarizing these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->